### PR TITLE
[v2] Rename Maybe methods

### DIFF
--- a/src/main/java/com/github/joselion/maybe/EffectHandler.java
+++ b/src/main/java/com/github/joselion/maybe/EffectHandler.java
@@ -11,7 +11,7 @@ import org.eclipse.jdt.annotation.Nullable;
  * effect operation. It can return back to maybe to continue linking operations,
  * or use termimal methods to return a safe value.
  * 
- * @param <E> the type of exception that the resolve operation may throw
+ * @param <E> the type of exception that the effect may throw
  * 
  * @author Jose Luis Leon
  * @since v0.3.2
@@ -88,7 +88,7 @@ public final class EffectHandler<E extends Exception> {
   /**
    * Throws the error if present. Does nothing otherwise.
    * 
-   * @throws E the error thrown by the {@code runEffect} operation
+   * @throws E the error thrown by the {@code effect} operation
    */
   public void onErrorThrow() throws E {
     if (error.isPresent()) {

--- a/src/main/java/com/github/joselion/maybe/Maybe.java
+++ b/src/main/java/com/github/joselion/maybe/Maybe.java
@@ -29,7 +29,7 @@ public final class Maybe<T> {
   }
 
   /**
-   * Returns a {@code Maybe} monad wrapping the given value. If the value is
+   * Returns a {@code Maybe} monadic wrapper of the given value. If the value is
    * {@code null}, it returns a {@link #nothing()}.
    * 
    * @param <T>   the type of the value
@@ -42,7 +42,7 @@ public final class Maybe<T> {
   }
 
   /**
-   * Returns a {@code Maybe} monad with nothing on it. This means the monad does
+   * Returns a {@code Maybe} monadic wrapper with nothing on it. This means the monad does
    * not contains a value because an exception may have occurred.
    * 
    * @param <T> the type of the value
@@ -63,7 +63,7 @@ public final class Maybe<T> {
    * @return a {@link ResolveHandler} with either the value resolved or the thrown
    *         exception to be handled
    */
-  public static <T, E extends Exception> ResolveHandler<T, E> resolve(final SupplierChecked<T, E> resolver) {
+  public static <T, E extends Exception> ResolveHandler<T, E> fromSupplier(final SupplierChecked<T, E> resolver) {
     try {
       return ResolveHandler.withSuccess(resolver.get());
     } catch (Exception e) {
@@ -84,7 +84,7 @@ public final class Maybe<T> {
    * @return an {@link EffectHandler} with either the thrown exception to be
    *         handled or nothing
    */
-  public static <E extends Exception> EffectHandler<E> runEffect(final RunnableChecked<E> effect) {
+  public static <E extends Exception> EffectHandler<E> fromRunnable(final RunnableChecked<E> effect) {
     try {
       effect.run();
       return EffectHandler.withNothing();
@@ -161,9 +161,9 @@ public final class Maybe<T> {
    * @return a {@link ResolveHandler} with either the value resolved or the thrown
    *         exception to be handled
    */
-  public <U, E extends Exception> ResolveHandler<U, E> thenResolve(final FunctionChecked<T, U, E> resolver) {
+  public <U, E extends Exception> ResolveHandler<U, E> resolve(final FunctionChecked<T, U, E> resolver) {
     if (value.isPresent()) {
-      return Maybe.resolve(() -> resolver.apply(value.get()));
+      return Maybe.fromSupplier(() -> resolver.apply(value.get()));
     }
 
     return ResolveHandler.withNothing();
@@ -178,9 +178,9 @@ public final class Maybe<T> {
    * @return an {@link EffectHandler} with either the thrown exception to be
    *         handled or nothing
    */
-  public <E extends Exception> EffectHandler<E> thenRunEffect(final ConsumerChecked<T, E> effect) {
+  public <E extends Exception> EffectHandler<E> runEffect(final ConsumerChecked<T, E> effect) {
     if (value.isPresent()) {
-      return Maybe.runEffect(() -> effect.accept(value.get()));
+      return Maybe.fromRunnable(() -> effect.accept(value.get()));
     }
 
     return EffectHandler.withNothing();

--- a/src/main/java/com/github/joselion/maybe/ResourceHolder.java
+++ b/src/main/java/com/github/joselion/maybe/ResourceHolder.java
@@ -10,7 +10,7 @@ import org.eclipse.jdt.annotation.Nullable;
 /**
  * ResourceSpec is a "middle step" API that allows to resolve or run an effect
  * usinga previously passed {@link AutoCloseable} resource. This resource will
- * be automatically closed after the {@code resolve} or the {@code runEffect}
+ * be automatically closed after the {@code resolve} or the {@code effect}
  * operation is finished.
  * 
  * @author Jose Luis Leon

--- a/src/test/java/com/github/joselion/maybe/EffectHandlerTest.java
+++ b/src/test/java/com/github/joselion/maybe/EffectHandlerTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
       @Nested class and_the_error_is_instance_of_the_checked_exception {
         @Test void the_handler_is_applied() {
           assertThat(
-            Maybe.runEffect(throwingOp)
+            Maybe.fromRunnable(throwingOp)
               .doOnError(error -> {
                 assertThat(error)
                   .isInstanceOf(IOException.class)
@@ -51,7 +51,7 @@ import org.junit.jupiter.api.Test;
             throw new UnsupportedOperationException("ERROR");
           };
           assertThat(
-            Maybe.runEffect(failingOp)
+            Maybe.fromRunnable(failingOp)
               .doOnError(error -> {
                 assertThat(error)
                   .isInstanceOf(UnsupportedOperationException.class)
@@ -67,7 +67,7 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_error_is_NOT_present {
       @Test void the_handler_is_NOT_applied() {
         assertThat(
-          Maybe.runEffect(noOp)
+          Maybe.fromRunnable(noOp)
             .doOnError(error -> {
               throw new AssertionError("The handler should not be executed");
             })
@@ -83,7 +83,7 @@ import org.junit.jupiter.api.Test;
       @Nested class and_is_instance_of_the_errorType_argument {
         @Test void catches_the_error_and_the_handler_is_applied() {
           assertThat(
-            Maybe.runEffect(throwingOp)
+            Maybe.fromRunnable(throwingOp)
               .catchError(IOException.class, error -> {
                 assertThat(error)
                   .isInstanceOf(IOException.class)
@@ -98,7 +98,7 @@ import org.junit.jupiter.api.Test;
       @Nested class and_is_NOT_instance_of_the_errorType_argument {
         @Test void the_error_is_NOT_catched_and_the_handler_is_not_applied() {
           assertThat(
-            Maybe.runEffect(throwingOp)
+            Maybe.fromRunnable(throwingOp)
               .catchError(EOFException.class, error -> {
                 throw new AssertionError("The handler should not be executed");
               })
@@ -112,7 +112,7 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_error_is_NOT_present {
       @Test void the_handler_is_NOT_applied() {
         assertThat(
-          Maybe.runEffect(noOp)
+          Maybe.fromRunnable(noOp)
             .catchError(RuntimeException.class, error -> {
               throw new AssertionError("The handler should not be executed");
             })
@@ -126,7 +126,7 @@ import org.junit.jupiter.api.Test;
   @Nested class onErrorThrow {
     @Nested class when_the_error_is_present {
       @Test void throws_an_exception() {
-        final EffectHandler<IOException> handler = Maybe.runEffect(throwingOp);
+        final EffectHandler<IOException> handler = Maybe.fromRunnable(throwingOp);
 
         assertThat(
           assertThrows(IOException.class, handler::onErrorThrow)
@@ -147,7 +147,7 @@ import org.junit.jupiter.api.Test;
 
     @Nested class when_the_error_is_NOT_present {
       @Test void no_exception_is_thrown() {
-        final EffectHandler<RuntimeException> handler = Maybe.runEffect(noOp);
+        final EffectHandler<RuntimeException> handler = Maybe.fromRunnable(noOp);
 
         assertThatCode(handler::onErrorThrow).doesNotThrowAnyException();
 
@@ -162,7 +162,7 @@ import org.junit.jupiter.api.Test;
   @Nested class toMaybe {
     @Test void returns_a_maybe_with_nothing() {
       assertThat(
-        Maybe.runEffect(throwingOp).toMaybe()
+        Maybe.fromRunnable(throwingOp).toMaybe()
       )
       .extracting(VALUE, optional(Void.class))
       .isEmpty();

--- a/src/test/java/com/github/joselion/maybe/MaybeTest.java
+++ b/src/test/java/com/github/joselion/maybe/MaybeTest.java
@@ -55,10 +55,10 @@ import org.junit.jupiter.api.Test;
     }
   }
 
-  @Nested class resolve {
+  @Nested class fromSupplier {
     @Nested class when_the_operation_success {
       @Test void returns_a_handler_with_the_value() {
-        final ResolveHandler<String, ?> handler = Maybe.resolve(() -> "OK");
+        final ResolveHandler<String, ?> handler = Maybe.fromSupplier(() -> "OK");
 
         assertThat(handler)
           .extracting(SUCCESS, optional(String.class))
@@ -73,7 +73,7 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_operation_fails {
       @Test void returns_a_handler_with_the_error() {
         final IOException exception = new IOException("FAIL");
-        final ResolveHandler<?, IOException> handler = Maybe.resolve(() -> {
+        final ResolveHandler<?, IOException> handler = Maybe.fromSupplier(() -> {
           throw exception;
         });
 
@@ -89,11 +89,11 @@ import org.junit.jupiter.api.Test;
     }
   }
 
-  @Nested class runEffect {
+  @Nested class fromRunnable {
     @Nested class when_the_operation_success {
       @Test void returns_a_handler_with_nothing() {
         final List<Integer> counter = new ArrayList<>();
-        final EffectHandler<?> handler = Maybe.runEffect(() -> {
+        final EffectHandler<?> handler = Maybe.fromRunnable(() -> {
           counter.add(1);
         });
 
@@ -108,7 +108,7 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_operation_fails {
       @Test void returns_a_handler_with_the_error() {
         final IOException exception = new IOException("FAIL");
-        final EffectHandler<IOException> handler = Maybe.runEffect(() -> {
+        final EffectHandler<IOException> handler = Maybe.fromRunnable(() -> {
           throw exception;
         });
 
@@ -125,7 +125,7 @@ import org.junit.jupiter.api.Test;
       try (
         AutoCloseableSoftAssertions softly = new AutoCloseableSoftAssertions();
         FileInputStream fis = Maybe.just("./src/test/resources/readTest.txt")
-          .thenResolve(FileInputStream::new)
+          .resolve(FileInputStream::new)
           .orThrow(Error::new);
       ) {
         softly.assertThat(Maybe.withResource(fis))
@@ -186,11 +186,11 @@ import org.junit.jupiter.api.Test;
     }
   }
 
-  @Nested class thenResolve {
+  @Nested class resolve {
     @Nested class when_the_previous_operation_resolves {
       @Test void the_then_operation_is_called_with_the_previous_value() {
         final ResolveHandler<String, ?> handler = Maybe.just(1)
-          .thenResolve(value -> {
+          .resolve(value -> {
             assertThat(value).isEqualTo(1);
             return "OK";
           });
@@ -208,7 +208,7 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_previous_operation_fails {
       @Test void the_then_operation_is_not_called() {
         final ResolveHandler<?, ?> handler = Maybe.nothing()
-          .thenResolve(value -> {
+          .resolve(value -> {
             throw new AssertionError("The then operation should not be executed");
           });
 
@@ -225,7 +225,7 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_new_operation_success {
       @Test void returns_the_a_handler_with_the_resolved_value() {
         final ResolveHandler<String, ?> handler = Maybe.just(3)
-          .thenResolve(value -> "OK".repeat(value));
+          .resolve(value -> "OK".repeat(value));
 
         assertThat(handler)
           .extracting(SUCCESS, optional(String.class))
@@ -241,7 +241,7 @@ import org.junit.jupiter.api.Test;
       @Test void returns_a_handler_with_the_error() {
         final IOException exception = new IOException("FAIL");
         final ResolveHandler<?, IOException> handler = Maybe.just(3)
-          .thenResolve(value -> {
+          .resolve(value -> {
             throw exception;
           });
 
@@ -257,15 +257,15 @@ import org.junit.jupiter.api.Test;
     }
   }
 
-  @Nested class thenRunEffect {
+  @Nested class runEffect {
     @Nested class when_the_previous_operation_resolves {
       @Test void the_then_operation_is_called_with_the_previous_value() {
         final EffectHandler<RuntimeException> handler = Maybe.just(1)
-          .thenRunEffect(value -> {
+          .runEffect(value -> {
             assertThat(value).isEqualTo(1);
           })
           .toMaybe()
-          .thenRunEffect(none -> {
+          .runEffect(none -> {
             assertThat(none).isExactlyInstanceOf(Void.class);
           });
 
@@ -278,7 +278,7 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_previous_operation_fails {
       @Test void the_then_operation_is_not_called() {
         final EffectHandler<RuntimeException> handler = Maybe.nothing()
-          .thenRunEffect(value -> {
+          .runEffect(value -> {
             throw new AssertionError("The then operation should not be executed");
           });
 
@@ -291,7 +291,7 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_new_operation_success {
       @Test void returns_the_a_handler_with_nothing() {
         final EffectHandler<RuntimeException> handler = Maybe.just(3)
-          .thenRunEffect(value -> {
+          .runEffect(value -> {
             assertThat(value).isEqualTo(3);
           });
 
@@ -305,7 +305,7 @@ import org.junit.jupiter.api.Test;
       @Test void returns_a_handler_with_the_error() {
         final IOException exception = new IOException("FAIL");
         final EffectHandler<IOException> handler = Maybe.just(3)
-          .thenRunEffect(value -> {
+          .runEffect(value -> {
             throw exception;
           });
 

--- a/src/test/java/com/github/joselion/maybe/ResolveHandlerTest.java
+++ b/src/test/java/com/github/joselion/maybe/ResolveHandlerTest.java
@@ -50,7 +50,7 @@ import org.junit.jupiter.api.Test;
       @Nested class and_the_error_is_instance_of_the_checked_exception {
         @Test void runs_the_effect() {
           final List<Integer> counter = new ArrayList<>();
-          final ResolveHandler<String, IOException> handler = Maybe.resolve(throwingOp)
+          final ResolveHandler<String, IOException> handler = Maybe.fromSupplier(throwingOp)
             .doOnError(error -> {
               assertThat(error)
                 .isInstanceOf(IOException.class)
@@ -74,7 +74,7 @@ import org.junit.jupiter.api.Test;
       @Nested class and_the_error_is_NOT_instance_of_the_checked_exception {
         @Test void runs_the_effect() {
           final List<Integer> counter = new ArrayList<>();
-          final ResolveHandler<String, IOException> handler = Maybe.resolve(errorOp)
+          final ResolveHandler<String, IOException> handler = Maybe.fromSupplier(errorOp)
             .doOnError(error -> {
               assertThat(error)
                 .isInstanceOf(UnsupportedOperationException.class)
@@ -98,7 +98,7 @@ import org.junit.jupiter.api.Test;
 
     @Nested class when_the_error_is_NOT_present {
       @Test void does_NOT_run_the_effect() {
-        final ResolveHandler<String, RuntimeException> handler = Maybe.resolve(okOp)
+        final ResolveHandler<String, RuntimeException> handler = Maybe.fromSupplier(okOp)
           .doOnError(error -> {
             throw new AssertionError("The handler should not be executed");
           });
@@ -118,7 +118,7 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_error_is_present {
       @Nested class and_the_error_is_instance_of_the_checked_exception {
         @Test void applies_the_handler_function() {
-          final ResolveHandler<String, IOException> handler = Maybe.resolve(throwingOp)
+          final ResolveHandler<String, IOException> handler = Maybe.fromSupplier(throwingOp)
             .onError(error -> {
               assertThat(error)
                 .isInstanceOf(IOException.class)
@@ -142,7 +142,7 @@ import org.junit.jupiter.api.Test;
           final SupplierChecked<String, IOException> failingOp = () -> {
             throw new UnsupportedOperationException("ERROR");
           };
-          final ResolveHandler<String, IOException> handler = Maybe.resolve(failingOp)
+          final ResolveHandler<String, IOException> handler = Maybe.fromSupplier(failingOp)
             .onError(error -> {
               assertThat(error)
                 .isInstanceOf(UnsupportedOperationException.class)
@@ -164,7 +164,7 @@ import org.junit.jupiter.api.Test;
 
     @Nested class when_the_error_is_NOT_present {
       @Test void the_error_handler_is_not_executed() {
-        final ResolveHandler<String, RuntimeException> handler = Maybe.resolve(okOp)
+        final ResolveHandler<String, RuntimeException> handler = Maybe.fromSupplier(okOp)
           .onError(error -> {
             throw new AssertionError("The handler should not be executed");
           });
@@ -184,7 +184,7 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_error_is_present {
       @Nested class and_is_instance_of_the_errorType_argument {
         @Test void catches_the_error_and_the_handler_is_applied() {
-          final ResolveHandler<String, IOException> handler = Maybe.resolve(throwingOp)
+          final ResolveHandler<String, IOException> handler = Maybe.fromSupplier(throwingOp)
             .catchError(IOException.class, error -> {
               assertThat(error)
                 .isInstanceOf(IOException.class)
@@ -205,7 +205,7 @@ import org.junit.jupiter.api.Test;
 
       @Nested class and_is_NOT_instance_of_the_errorType_argument {
         @Test void the_error_is_NOT_catched_and_the_handler_is_not_applied() {
-          final ResolveHandler<String, IOException> handler = Maybe.resolve(throwingOp)
+          final ResolveHandler<String, IOException> handler = Maybe.fromSupplier(throwingOp)
             .catchError(EOFException.class, error -> {
               throw new AssertionError("The handler should not be executed");
             });
@@ -223,7 +223,7 @@ import org.junit.jupiter.api.Test;
 
     @Nested class when_the_error_is_NOT_present {
       @Test void the_error_handler_is_not_executed() {
-        final ResolveHandler<String, RuntimeException> handler = Maybe.resolve(okOp)
+        final ResolveHandler<String, RuntimeException> handler = Maybe.fromSupplier(okOp)
           .catchError(RuntimeException.class, error -> {
             throw new AssertionError("The handler should not be executed");
           });
@@ -425,7 +425,7 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_value_is_present {
       @Test void returns_the_value() {
         assertThat(
-          Maybe.resolve(okOp)
+          Maybe.fromSupplier(okOp)
             .orDefault("OTHER")
         )
         .isEqualTo("OK");
@@ -435,7 +435,7 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_value_is_NOT_present {
       @Test void returns_the_default_value() {
         assertThat(
-          Maybe.resolve(throwingOp)
+          Maybe.fromSupplier(throwingOp)
             .orDefault("OTHER")
         )
         .isEqualTo("OTHER");
@@ -447,7 +447,7 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_value_is_present {
       @Test void returns_the_value() {
         assertThat(
-          Maybe.resolve(okOp)
+          Maybe.fromSupplier(okOp)
             .orSupplyDefault(() -> "OTHER")
         )
         .isEqualTo("OK");
@@ -457,7 +457,7 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_value_is_NOT_present {
       @Test void returns_the_default_value() {
         assertThat(
-          Maybe.resolve(throwingOp)
+          Maybe.fromSupplier(throwingOp)
             .orSupplyDefault(() -> "OTHER")
         )
         .isEqualTo("OTHER");
@@ -469,12 +469,12 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_value_is_present {
       @Test void returns_the_value() throws EOFException {
         assertThat(
-          Maybe.resolve(okOp).orThrow()
+          Maybe.fromSupplier(okOp).orThrow()
         )
         .isEqualTo("OK");
 
         assertThat(
-          Maybe.resolve(okOp).orThrow(error -> new EOFException(error.getMessage()))
+          Maybe.fromSupplier(okOp).orThrow(error -> new EOFException(error.getMessage()))
         )
         .isEqualTo("OK");
       }
@@ -482,7 +482,7 @@ import org.junit.jupiter.api.Test;
 
     @Nested class when_the_value_is_NOT_present {
       @Test void throws_the_error() {
-        final ResolveHandler<?, IOException> handler = Maybe.resolve(throwingOp);
+        final ResolveHandler<?, IOException> handler = Maybe.fromSupplier(throwingOp);
 
         assertThat(
           assertThrows(IOException.class, handler::orThrow)
@@ -506,7 +506,7 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_value_is_present {
       @Test void returns_a_maybe_with_the_value() {
         assertThat(
-          Maybe.resolve(okOp).toMaybe()
+          Maybe.fromSupplier(okOp).toMaybe()
         )
         .extracting(VALUE, optional(String.class))
         .contains("OK");
@@ -516,7 +516,7 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_value_is_NOT_present {
       @Test void returns_a_maybe_with_nothing() {
         assertThat(
-          Maybe.resolve(throwingOp).toMaybe()
+          Maybe.fromSupplier(throwingOp).toMaybe()
         )
         .extracting(VALUE, optional(String.class))
         .isEmpty();
@@ -527,13 +527,13 @@ import org.junit.jupiter.api.Test;
   @Nested class toOptional {
     @Nested class when_the_value_is_present {
       @Test void returns_the_value_wrapped_in_an_optinal() {
-        assertThat(Maybe.resolve(okOp).toOptional()).contains("OK");
+        assertThat(Maybe.fromSupplier(okOp).toOptional()).contains("OK");
       }
     }
 
     @Nested class when_the_value_is_NOT_present {
       @Test void returns_an_empty_optional() {
-        assertThat(Maybe.resolve(throwingOp).toOptional()).isEmpty();
+        assertThat(Maybe.fromSupplier(throwingOp).toOptional()).isEmpty();
       }
     }
   }
@@ -542,7 +542,7 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_value_is_present {
       @Test void returns_a_resource_holder_with_the_mapped_value() {
         final ResourceHolder<FileInputStream> resHolder = Maybe.just("./src/test/resources/readTest.txt")
-          .thenResolve(FileInputStream::new)
+          .resolve(FileInputStream::new)
           .mapToResource(Function.identity());
 
         assertThat(resHolder)
@@ -556,7 +556,7 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_error_is_NOT_present {
       @Test void returns_an_empty_resource_holder() {
         final ResourceHolder<FileInputStream> resHolder = Maybe.just("invalidFile.txt")
-          .thenResolve(FileInputStream::new)
+          .resolve(FileInputStream::new)
           .mapToResource(Function.identity());
 
         assertThat(resHolder)

--- a/src/test/java/com/github/joselion/maybe/ResourceHolderTest.java
+++ b/src/test/java/com/github/joselion/maybe/ResourceHolderTest.java
@@ -161,7 +161,7 @@ import org.junit.jupiter.api.Test;
 
   private FileInputStream getFIS() {
     return Maybe.just(FILE_PATH)
-      .thenResolve(FileInputStream::new)
+      .resolve(FileInputStream::new)
       .orThrow(Error::new);
   }
 }


### PR DESCRIPTION
Renamed as follows:
- `.resolve(..)` → `.fromSupplier(..)`
- `thenResolve(..)` → `.resolve(..)`
- `.runEffect(..)` → `.fromRunnable(..)`
- `.thenRunEffect(..)` → `.runEffect(..)`