### PR TITLE
[v2] EffectHandler error handling refactor

### DIFF
--- a/src/test/java/com/github/joselion/maybe/EffectHandlerTest.java
+++ b/src/test/java/com/github/joselion/maybe/EffectHandlerTest.java
@@ -1,11 +1,19 @@
 package com.github.joselion.maybe;
 
+import static com.github.joselion.maybe.helpers.Helpers.spyLambda;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-import java.io.EOFException;
-import java.io.IOException;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.FileSystemException;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import com.github.joselion.maybe.helpers.UnitTest;
 import com.github.joselion.maybe.util.RunnableChecked;
@@ -15,106 +23,154 @@ import org.junit.jupiter.api.Test;
 
 @UnitTest class EffectHandlerTest {
 
-  private static final IOException FAIL_EXCEPTION = new IOException("FAIL");
+  private static final FileSystemException FAIL_EXCEPTION = new FileSystemException("FAIL");
 
-  private final RunnableChecked<IOException> throwingOp = () -> {
+  private final RunnableChecked<FileSystemException> throwingOp = () -> {
     throw FAIL_EXCEPTION;
   };
 
   private final RunnableChecked<RuntimeException> noOp = () -> { };
 
-  @Nested class onError {
+  @Nested class doOnError {
     @Nested class when_the_error_is_present {
-      @Nested class and_the_error_is_instance_of_the_checked_exception {
-        @Test void the_handler_is_applied() {
-          assertThat(
+      @Nested class and_the_error_type_is_provided {
+        @Nested class and_the_error_is_an_instance_of_the_provided_type {
+          @Test void calls_the_effect_callback() {
+            final Consumer<FileSystemException> consumerSpy = spyLambda(error -> { });
+            final Runnable runnableSpy = spyLambda(() -> { });
+
             Maybe.fromRunnable(throwingOp)
-              .doOnError(error -> {
-                assertThat(error)
-                  .isInstanceOf(IOException.class)
-                  .hasMessageContaining("FAIL");
-              })
-              .error()
-          )
-          .isEmpty();
+              .doOnError(FileSystemException.class, consumerSpy)
+              .doOnError(FileSystemException.class, runnableSpy);
+
+            verify(consumerSpy, times(1)).accept(FAIL_EXCEPTION);
+            verify(runnableSpy, times(1)).run();;
+          }
+        }
+
+        @Nested class and_the_error_is_NOT_an_instance_of_the_provided_type {
+          @Test void never_calls_the_effect_callback() {
+            final Consumer<RuntimeException> consumerSpy = spyLambda(error -> { });
+            final Runnable runnableSpy = spyLambda(() -> { });
+
+            Maybe.fromRunnable(throwingOp)
+              .doOnError(RuntimeException.class, consumerSpy)
+              .doOnError(RuntimeException.class, runnableSpy);
+
+            verify(consumerSpy, never()).accept(any());
+            verify(runnableSpy, never()).run();
+          }
         }
       }
 
-      @Nested class and_the_error_is_NOT_instance_of_the_checked_exception {
-        @Test void the_handler_is_applied() {
-          final RunnableChecked<IOException> failingOp = () -> {
-            throw new UnsupportedOperationException("ERROR");
-          };
+      @Nested class and_the_error_type_is_NOT_provided {
+        @Test void calls_the_effect_callback() {
+          final Consumer<FileSystemException> consumerSpy = spyLambda(error -> { });
+          final Runnable runnableSpy = spyLambda(() -> { });
 
-          assertThat(
-            Maybe.fromRunnable(failingOp)
-              .doOnError(error -> {
-                assertThat(error)
-                  .isInstanceOf(UnsupportedOperationException.class)
-                  .hasMessageContaining("ERROR");
-              })
-              .error()
-          )
-          .isEmpty();
+          Maybe.fromRunnable(throwingOp)
+            .doOnError(consumerSpy)
+            .doOnError(runnableSpy);
+
+          verify(consumerSpy, times(1)).accept(FAIL_EXCEPTION);
+          verify(runnableSpy, times(1)).run();
         }
       }
     }
 
     @Nested class when_the_error_is_NOT_present {
-      @Test void the_handler_is_NOT_applied() {
-        assertThat(
-          Maybe.fromRunnable(noOp)
-            .doOnError(error -> {
-              throw new AssertionError("The handler should not be executed");
-            })
-            .error()
-        )
-        .isEmpty();
+      @Test void never_calls_the_effect_callback() {
+        final Consumer<RuntimeException> cunsumerSpy = spyLambda(error -> { });
+        final Runnable runnableSpy = spyLambda(() -> { });
+
+        Maybe.fromRunnable(noOp)
+          .doOnError(RuntimeException.class, cunsumerSpy)
+          .doOnError(RuntimeException.class, runnableSpy)
+          .doOnError(cunsumerSpy)
+          .doOnError(runnableSpy);
+
+        verify(cunsumerSpy, never()).accept(any());
+        verify(runnableSpy, never()).run();
       }
     }
   }
 
   @Nested class catchError {
     @Nested class when_the_error_is_present {
-      @Nested class and_is_instance_of_the_errorType_argument {
-        @Test void catches_the_error_and_the_handler_is_applied() {
-          assertThat(
-            Maybe.fromRunnable(throwingOp)
-              .catchError(IOException.class, error -> {
-                assertThat(error)
-                  .isInstanceOf(IOException.class)
-                  .hasMessage("FAIL");
-              })
-              .error()
-          )
-          .isEmpty();
+      @Nested class and_the_error_type_is_provided {
+        @Nested class and_the_error_is_an_instance_of_the_provided_type {
+          @Test void calls_the_handler_function() {
+            final Consumer<FileSystemException> consumerSpy = spyLambda(e -> { });
+            final Runnable runnableSpy = spyLambda(() -> { });
+            final List<EffectHandler<FileSystemException>> handlers = List.of(
+              Maybe.fromRunnable(throwingOp).catchError(FileSystemException.class, consumerSpy),
+              Maybe.fromRunnable(throwingOp).catchError(FileSystemException.class, runnableSpy)
+            );
+
+            assertThat(handlers).isNotEmpty().allSatisfy(handler -> {
+              assertThat(handler.error()).isEmpty();
+            });
+
+            verify(consumerSpy, times(1)).accept(FAIL_EXCEPTION);
+            verify(runnableSpy, times(1)).run();
+          }
+        }
+
+        @Nested class and_the_error_is_NOT_an_instance_of_the_provided_type {
+          @Test void never_calls_the_handler_function() {
+            final Consumer<AccessDeniedException> consumerSpy = spyLambda(e -> { });
+            final Runnable runnableSpy = spyLambda(() -> { });
+            final List<EffectHandler<FileSystemException>> handlers = List.of(
+              Maybe.fromRunnable(throwingOp).catchError(AccessDeniedException.class, consumerSpy),
+              Maybe.fromRunnable(throwingOp).catchError(AccessDeniedException.class, runnableSpy)
+            );
+
+            assertThat(handlers).isNotEmpty().allSatisfy(handler -> {
+              assertThat(handler.error()).contains(FAIL_EXCEPTION);
+            });
+
+            verify(consumerSpy, never()).accept(any());
+            verify(runnableSpy, never()).run();
+          }
         }
       }
 
-      @Nested class and_is_NOT_instance_of_the_errorType_argument {
-        @Test void the_error_is_NOT_catched_and_the_handler_is_not_applied() {
-          assertThat(
-            Maybe.fromRunnable(throwingOp)
-              .catchError(EOFException.class, error -> {
-                throw new AssertionError("The handler should not be executed");
-              })
-              .error()
-          )
-          .contains(FAIL_EXCEPTION);
+      @Nested class and_the_error_type_is_NOT_provided {
+        @Test void calls_the_handler_function() {
+          final Consumer<FileSystemException> consumerSpy = spyLambda(e -> { });
+          final Runnable runnableSpy = spyLambda(() -> { });
+          final List<EffectHandler<FileSystemException>> handlers = List.of(
+            Maybe.fromRunnable(throwingOp).catchError(consumerSpy),
+            Maybe.fromRunnable(throwingOp).catchError(runnableSpy)
+          );
+
+          assertThat(handlers).isNotEmpty().allSatisfy(handler -> {
+            assertThat(handler.error()).isEmpty();
+          });
+
+          verify(consumerSpy, times(1)).accept(FAIL_EXCEPTION);
+          verify(runnableSpy, times(1)).run();
         }
       }
     }
 
     @Nested class when_the_error_is_NOT_present {
-      @Test void the_handler_is_NOT_applied() {
-        assertThat(
-          Maybe.fromRunnable(noOp)
-            .catchError(RuntimeException.class, error -> {
-              throw new AssertionError("The handler should not be executed");
-            })
-            .error()
-        )
-        .isEmpty();
+      @Test void never_calls_the_handler_function() {
+        final Consumer<RuntimeException> consumerSpy = spyLambda(e -> { });
+        final Runnable runnableSpy = spyLambda(() -> { });
+        final List<EffectHandler<RuntimeException>> handlers = List.of(
+          Maybe.fromRunnable(noOp).catchError(RuntimeException.class, consumerSpy),
+          Maybe.fromRunnable(noOp).catchError(RuntimeException.class, runnableSpy),
+          Maybe.fromRunnable(noOp).catchError(consumerSpy),
+          Maybe.fromRunnable(noOp).catchError(runnableSpy)
+        );
+
+        assertThat(handlers).isNotEmpty().allSatisfy(handler -> {
+          assertThat(handler.error()).isEmpty();
+        });
+
+        verify(consumerSpy, never()).accept(any());
+        verify(runnableSpy, never()).run();
       }
     }
   }
@@ -122,35 +178,26 @@ import org.junit.jupiter.api.Test;
   @Nested class onErrorThrow {
     @Nested class when_the_error_is_present {
       @Test void throws_an_exception() {
-        final EffectHandler<IOException> handler = Maybe.fromRunnable(throwingOp);
+        final RuntimeException anotherError = new RuntimeException("OTHER");
+        final Function<FileSystemException, RuntimeException> functionSpy = spyLambda(err -> anotherError);
+        final EffectHandler<FileSystemException> handler = Maybe.fromRunnable(throwingOp);
 
-        assertThat(
-          assertThrows(IOException.class, handler::onErrorThrow)
-        )
-        .isInstanceOf(IOException.class)
-        .hasMessage("FAIL");
+        assertThatThrownBy(handler::onErrorThrow).isEqualTo(FAIL_EXCEPTION);
+        assertThatThrownBy(() -> handler.onErrorThrow(functionSpy)).isEqualTo(anotherError);
 
-        assertThat(
-          assertThrows(
-            EOFException.class,
-            () -> handler.onErrorThrow(error -> new EOFException(error.getMessage() + " - OTHER ERROR"))
-          )
-        )
-        .isExactlyInstanceOf(EOFException.class)
-        .hasMessage("FAIL - OTHER ERROR");
+        verify(functionSpy, times(1)).apply(FAIL_EXCEPTION);
       }
     }
 
     @Nested class when_the_error_is_NOT_present {
       @Test void no_exception_is_thrown() {
+        final Function<RuntimeException, FileSystemException> functionSpy = spyLambda(err -> FAIL_EXCEPTION);
         final EffectHandler<RuntimeException> handler = Maybe.fromRunnable(noOp);
 
         assertThatCode(handler::onErrorThrow).doesNotThrowAnyException();
+        assertThatCode(() -> handler.onErrorThrow(functionSpy)).doesNotThrowAnyException();
 
-        assertThatCode(() -> {
-          handler.onErrorThrow(error -> new EOFException(error.getMessage() + " - OTHER ERROR"));
-        })
-        .doesNotThrowAnyException();
+        verify(functionSpy, never()).apply(any());
       }
     }
   }

--- a/src/test/java/com/github/joselion/maybe/MaybeTest.java
+++ b/src/test/java/com/github/joselion/maybe/MaybeTest.java
@@ -15,12 +15,14 @@ import org.junit.jupiter.api.Test;
 
 @UnitTest class MaybeTest {
 
+  private static final String OK = "OK";
+
   @Nested class just {
     @Nested class when_a_value_is_passed {
       @Test void returns_the_monad_with_the_value() {
-        final Maybe<String> maybe = Maybe.just("foo");
+        final Maybe<String> maybe = Maybe.just(OK);
 
-        assertThat(maybe.value()).contains("foo");
+        assertThat(maybe.value()).contains(OK);
       }
     }
 
@@ -45,9 +47,9 @@ import org.junit.jupiter.api.Test;
   @Nested class fromSupplier {
     @Nested class when_the_operation_success {
       @Test void returns_a_handler_with_the_value() {
-        final ResolveHandler<String, ?> handler = Maybe.fromSupplier(() -> "OK");
+        final ResolveHandler<String, ?> handler = Maybe.fromSupplier(() -> OK);
 
-        assertThat(handler.success()).contains("OK");
+        assertThat(handler.success()).contains(OK);
         assertThat(handler.error()).isEmpty();
       }
     }
@@ -111,7 +113,7 @@ import org.junit.jupiter.api.Test;
   @Nested class map {
     @Nested class when_there_is_a_value_in_the_monad {
       @Test void maps_the_value_with_the_passed_function() {
-        final Maybe<Integer> maybe = Maybe.just("OK").map(String::length);
+        final Maybe<Integer> maybe = Maybe.just(OK).map(String::length);
 
         assertThat(maybe.value()).contains(2);
       }
@@ -129,7 +131,7 @@ import org.junit.jupiter.api.Test;
   @Nested class flatMap {
     @Nested class when_there_is_a_value_in_the_monad {
       @Test void maps_the_value_with_the_passed_maybe_function() {
-        final Maybe<Integer> maybe = Maybe.just("OK").flatMap(str -> Maybe.just(str.length()));
+        final Maybe<Integer> maybe = Maybe.just(OK).flatMap(str -> Maybe.just(str.length()));
 
         assertThat(maybe.value()).contains(2);
       }
@@ -151,10 +153,10 @@ import org.junit.jupiter.api.Test;
         final ResolveHandler<String, ?> handler = Maybe.just(1)
           .resolve(value -> {
             assertThat(value).isEqualTo(1);
-            return "OK";
+            return OK;
           });
 
-        assertThat(handler.success()).contains("OK");
+        assertThat(handler.success()).contains(OK);
         assertThat(handler.error()).isEmpty();
       }
     }
@@ -174,7 +176,7 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_new_operation_success {
       @Test void returns_the_a_handler_with_the_resolved_value() {
         final ResolveHandler<String, ?> handler = Maybe.just(3)
-          .resolve(value -> "OK".repeat(value));
+          .resolve(value -> OK.repeat(value));
 
         assertThat(handler.success()).contains("OKOKOK");
         assertThat(handler.error()).isEmpty();
@@ -267,7 +269,7 @@ import org.junit.jupiter.api.Test;
   @Nested class hasValue {
     @Nested class when_there_is_a_value_in_the_monad {
       @Test void returns_true() {
-        assertThat(Maybe.just("OK").hasValue()).isTrue();
+        assertThat(Maybe.just(OK).hasValue()).isTrue();
       }
     }
 
@@ -287,17 +289,17 @@ import org.junit.jupiter.api.Test;
 
     @Nested class when_there_is_a_value_in_the_monad {
       @Test void returns_false() {
-        assertThat(Maybe.just("OK").hasNothing()).isFalse();
+        assertThat(Maybe.just(OK).hasNothing()).isFalse();
       }
     }
   }
 
   @Nested class toOptional {
     @Test void returns_the_value_of_the_monad_as_optional() {
-      final Maybe<String> maybe = Maybe.just("OK");
+      final Maybe<String> maybe = Maybe.just(OK);
 
       assertThat(maybe.toOptional())
-        .contains("OK");
+        .contains(OK);
     }
   }
 
@@ -324,8 +326,8 @@ import org.junit.jupiter.api.Test;
 
     @Nested class when_both_wrapped_values_are_equal {
       @Test void returns_true() {
-        final Maybe<String> maybe = Maybe.just("OK");
-        final Maybe<String> other = Maybe.just("OK");
+        final Maybe<String> maybe = Maybe.just(OK);
+        final Maybe<String> other = Maybe.just(OK);
         final boolean isEqual = maybe.equals(other);
 
         assertThat(isEqual).isTrue();
@@ -334,7 +336,7 @@ import org.junit.jupiter.api.Test;
 
     @Nested class when_both_wrapped_values_are_NOT_equal {
       @Test void returns_false() {
-        final Maybe<String> maybe = Maybe.just("OK");
+        final Maybe<String> maybe = Maybe.just(OK);
         final Maybe<String> other = Maybe.just("OTHER");
         final boolean isEqualToOther = maybe.equals(other);
 
@@ -346,9 +348,9 @@ import org.junit.jupiter.api.Test;
   @Nested class hashCode {
     @Nested class when_there_is_a_value_in_the_monad {
       @Test void returns_the_hash_code_of_the_value() {
-        final Maybe<String> maybe = Maybe.just("OK");
+        final Maybe<String> maybe = Maybe.just(OK);
 
-        assertThat(maybe).hasSameHashCodeAs("OK");
+        assertThat(maybe).hasSameHashCodeAs(OK);
       }
     }
 
@@ -364,7 +366,7 @@ import org.junit.jupiter.api.Test;
   @Nested class toString {
     @Nested class when_there_is_a_value_in_the_monad {
       @Test void returns_the_string_representation_of_the_value() {
-        final Maybe<String> maybe = Maybe.just("OK");
+        final Maybe<String> maybe = Maybe.just(OK);
 
         assertThat(maybe).hasToString("Maybe[OK]");
       }


### PR DESCRIPTION
Refactor error handling of `EffectHandler`:
- Fix `.doOnError(..)` to not recover from the error
- Add `.doOnError(..)` overload without specific type, with `Runnable`
- Add `.doOnError(..)` overload matching specific type, with `Consumer<X>`
- Add `.doOnError(..)` overload matching specific type, with `Runnable`
- Add `.catchError(..)` overload matching specific type, with `Runnable`
- Add `.catchError(..)` overload without specific type, with `Consumer<E>`
- Add `.catchError(..)` overload without specific type, with `Runnable`