### PR TITLE
[v2] Partial creator overloads

### DIFF
--- a/src/main/java/com/github/joselion/maybe/Maybe.java
+++ b/src/main/java/com/github/joselion/maybe/Maybe.java
@@ -72,7 +72,7 @@ public final class Maybe<T> {
    * @return a {@link ResolveHandler} with either the value resolved or the thrown
    *         exception to be handled
    */
-  public static <T, E extends Exception> ResolveHandler<T, E> fromSupplier(final SupplierChecked<T, E> resolver) {
+  public static <T, E extends Exception> ResolveHandler<T, E> fromResolver(final SupplierChecked<T, E> resolver) {
     try {
       return ResolveHandler.withSuccess(resolver.get());
     } catch (Exception e) {
@@ -81,6 +81,38 @@ public final class Maybe<T> {
 
       return ResolveHandler.withError(error);
     }
+  }
+
+  /**
+   * Convenience partial application of a {@code resolver}. This method creates
+   * a function that receives any external value of type {@code S}, and produces
+   * a {@link ResolveHandler} once applied. This is specially useful when we
+   * want to create a {@link Maybe} from a callback argument, like on a
+   * {@link Optional#map(Function)} for instance.
+   * <p>For example, the following code:
+   * <pre>
+   *  Optional.of(value)
+   *    .map(str -> Maybe.fromResolver(() -> decode(str)));
+   * </pre>
+   * Is equivalent to:
+   * <pre>
+   *  Optional.of(value)
+   *    .map(Maybe.fromResolver(this::decode));
+   * </pre>
+   *
+   * @param <S> the external value type
+   * @param <T> the type of the value to be resolved
+   * @param <E> the type of the error the resolver may throw
+   * @param resolver a checked function that receives an external value
+   *                 {@code S} and produces a value {@code T}
+   * @return a partially applied {@link ResolveHandler}. That is, a function
+   *         that receives an external value {@code S}, and produces a new
+   *         handler {@code ResolveHandler<T, E>}
+   */
+  public static <S, T, E extends Exception> Function<S, ResolveHandler<T, E>> fromResolver(
+    final FunctionChecked<S, T, E> resolver
+  ) {
+    return injected -> Maybe.fromResolver(() -> resolver.apply(injected));
   }
 
   /**
@@ -93,7 +125,7 @@ public final class Maybe<T> {
    * @return an {@link EffectHandler} with either the thrown exception to be
    *         handled or nothing
    */
-  public static <E extends Exception> EffectHandler<E> fromRunnable(final RunnableChecked<E> effect) {
+  public static <E extends Exception> EffectHandler<E> fromEffect(final RunnableChecked<E> effect) {
     try {
       effect.run();
       return EffectHandler.withNothing();
@@ -103,6 +135,36 @@ public final class Maybe<T> {
 
       return EffectHandler.withError(error);
     }
+  }
+
+  /**
+   * Convenience partial application of an {@code effect}. This method creates
+   * a function that receives any external value of type {@code S}, and produces
+   * a {@link EffectHandler} once applied. This is specially useful when we
+   * want to create a {@link Maybe} from a callback argument, like on a
+   * {@link Optional#map(Function)} for instance.
+   * <p>For example, the following code:
+   * <pre>
+   *  Optional.of(value)
+   *    .map(msg -> Maybe.fromEffect(() -> sendMessage(msg)));
+   * </pre>
+   * Is equivalent to:
+   * <pre>
+   *  Optional.of(value)
+   *    .map(Maybe.fromEffect(this::sendMessage));
+   * </pre>
+   *
+   * @param <S> the external value type
+   * @param <E> the type of the error the resolver may throw
+   * @param effect a checked consumer that receives an external value {@code S}
+   * @return a partially applied {@link EffectHandler}. That is, a function
+   *         that receives an external value {@code S}, and produces a new
+   *         handler {@code EffectHandler<E>}
+   */
+  public static <S, E extends Exception> Function<S, EffectHandler<E>> fromEffect(
+    final ConsumerChecked<S, E> effect
+  ) {
+    return injected -> Maybe.fromEffect(() -> effect.accept(injected));
   }
 
   /**
@@ -172,7 +234,7 @@ public final class Maybe<T> {
    */
   public <U, E extends Exception> ResolveHandler<U, E> resolve(final FunctionChecked<T, U, E> resolver) {
     if (value.isPresent()) {
-      return Maybe.fromSupplier(() -> resolver.apply(value.get()));
+      return Maybe.fromResolver(() -> resolver.apply(value.get()));
     }
 
     return ResolveHandler.withNothing();
@@ -189,7 +251,7 @@ public final class Maybe<T> {
    */
   public <E extends Exception> EffectHandler<E> runEffect(final ConsumerChecked<T, E> effect) {
     if (value.isPresent()) {
-      return Maybe.fromRunnable(() -> effect.accept(value.get()));
+      return Maybe.fromEffect(() -> effect.accept(value.get()));
     }
 
     return EffectHandler.withNothing();

--- a/src/main/java/com/github/joselion/maybe/util/FunctionChecked.java
+++ b/src/main/java/com/github/joselion/maybe/util/FunctionChecked.java
@@ -24,4 +24,15 @@ public interface FunctionChecked<T, R, E extends Exception> {
    * @throws E which extends from {@link Exception}
    */
   R apply(T t) throws E;
+
+  /**
+   * Returns a function that always returns its input argument.
+   *
+   * @param <T> the type of the input and output objects to the function
+   * @param <E> the type of exception that the function throws
+   * @return a function that always returns its input argument
+   */
+  static <T, E extends Exception> FunctionChecked<T, T, E> identity() {
+      return t -> t;
+  }
 }

--- a/src/test/java/com/github/joselion/maybe/EffectHandlerTest.java
+++ b/src/test/java/com/github/joselion/maybe/EffectHandlerTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
       @Test void calls_the_effect_callback() {
         final Runnable runnableSpy = spyLambda(() -> { });
 
-        Maybe.fromRunnable(noOp).doOnSuccess(runnableSpy);
+        Maybe.fromEffect(noOp).doOnSuccess(runnableSpy);
 
         verify(runnableSpy, times(1)).run();
       }
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.Test;
       @Test void never_calls_the_effect_callback() {
         final Runnable runnableSpy = spyLambda(() -> { });
 
-        Maybe.fromRunnable(throwingOp).doOnSuccess(runnableSpy);
+        Maybe.fromEffect(throwingOp).doOnSuccess(runnableSpy);
 
         verify(runnableSpy, never()).run();
       }
@@ -61,7 +61,7 @@ import org.junit.jupiter.api.Test;
             final Consumer<FileSystemException> consumerSpy = spyLambda(error -> { });
             final Runnable runnableSpy = spyLambda(() -> { });
 
-            Maybe.fromRunnable(throwingOp)
+            Maybe.fromEffect(throwingOp)
               .doOnError(FileSystemException.class, consumerSpy)
               .doOnError(FileSystemException.class, runnableSpy);
 
@@ -75,7 +75,7 @@ import org.junit.jupiter.api.Test;
             final Consumer<RuntimeException> consumerSpy = spyLambda(error -> { });
             final Runnable runnableSpy = spyLambda(() -> { });
 
-            Maybe.fromRunnable(throwingOp)
+            Maybe.fromEffect(throwingOp)
               .doOnError(RuntimeException.class, consumerSpy)
               .doOnError(RuntimeException.class, runnableSpy);
 
@@ -90,7 +90,7 @@ import org.junit.jupiter.api.Test;
           final Consumer<FileSystemException> consumerSpy = spyLambda(error -> { });
           final Runnable runnableSpy = spyLambda(() -> { });
 
-          Maybe.fromRunnable(throwingOp)
+          Maybe.fromEffect(throwingOp)
             .doOnError(consumerSpy)
             .doOnError(runnableSpy);
 
@@ -105,7 +105,7 @@ import org.junit.jupiter.api.Test;
         final Consumer<RuntimeException> cunsumerSpy = spyLambda(error -> { });
         final Runnable runnableSpy = spyLambda(() -> { });
 
-        Maybe.fromRunnable(noOp)
+        Maybe.fromEffect(noOp)
           .doOnError(RuntimeException.class, cunsumerSpy)
           .doOnError(RuntimeException.class, runnableSpy)
           .doOnError(cunsumerSpy)
@@ -125,8 +125,8 @@ import org.junit.jupiter.api.Test;
             final Consumer<FileSystemException> consumerSpy = spyLambda(e -> { });
             final Runnable runnableSpy = spyLambda(() -> { });
             final List<EffectHandler<FileSystemException>> handlers = List.of(
-              Maybe.fromRunnable(throwingOp).catchError(FileSystemException.class, consumerSpy),
-              Maybe.fromRunnable(throwingOp).catchError(FileSystemException.class, runnableSpy)
+              Maybe.fromEffect(throwingOp).catchError(FileSystemException.class, consumerSpy),
+              Maybe.fromEffect(throwingOp).catchError(FileSystemException.class, runnableSpy)
             );
 
             assertThat(handlers).isNotEmpty().allSatisfy(handler -> {
@@ -143,8 +143,8 @@ import org.junit.jupiter.api.Test;
             final Consumer<AccessDeniedException> consumerSpy = spyLambda(e -> { });
             final Runnable runnableSpy = spyLambda(() -> { });
             final List<EffectHandler<FileSystemException>> handlers = List.of(
-              Maybe.fromRunnable(throwingOp).catchError(AccessDeniedException.class, consumerSpy),
-              Maybe.fromRunnable(throwingOp).catchError(AccessDeniedException.class, runnableSpy)
+              Maybe.fromEffect(throwingOp).catchError(AccessDeniedException.class, consumerSpy),
+              Maybe.fromEffect(throwingOp).catchError(AccessDeniedException.class, runnableSpy)
             );
 
             assertThat(handlers).isNotEmpty().allSatisfy(handler -> {
@@ -162,8 +162,8 @@ import org.junit.jupiter.api.Test;
           final Consumer<FileSystemException> consumerSpy = spyLambda(e -> { });
           final Runnable runnableSpy = spyLambda(() -> { });
           final List<EffectHandler<FileSystemException>> handlers = List.of(
-            Maybe.fromRunnable(throwingOp).catchError(consumerSpy),
-            Maybe.fromRunnable(throwingOp).catchError(runnableSpy)
+            Maybe.fromEffect(throwingOp).catchError(consumerSpy),
+            Maybe.fromEffect(throwingOp).catchError(runnableSpy)
           );
 
           assertThat(handlers).isNotEmpty().allSatisfy(handler -> {
@@ -181,10 +181,10 @@ import org.junit.jupiter.api.Test;
         final Consumer<RuntimeException> consumerSpy = spyLambda(e -> { });
         final Runnable runnableSpy = spyLambda(() -> { });
         final List<EffectHandler<RuntimeException>> handlers = List.of(
-          Maybe.fromRunnable(noOp).catchError(RuntimeException.class, consumerSpy),
-          Maybe.fromRunnable(noOp).catchError(RuntimeException.class, runnableSpy),
-          Maybe.fromRunnable(noOp).catchError(consumerSpy),
-          Maybe.fromRunnable(noOp).catchError(runnableSpy)
+          Maybe.fromEffect(noOp).catchError(RuntimeException.class, consumerSpy),
+          Maybe.fromEffect(noOp).catchError(RuntimeException.class, runnableSpy),
+          Maybe.fromEffect(noOp).catchError(consumerSpy),
+          Maybe.fromEffect(noOp).catchError(runnableSpy)
         );
 
         assertThat(handlers).isNotEmpty().allSatisfy(handler -> {
@@ -202,7 +202,7 @@ import org.junit.jupiter.api.Test;
       @Test void calls_the_effect_callback() {
         final Consumer<FileSystemException> consumerSpy = spyLambda(e -> { });
         final Runnable runnableSpy = spyLambda(() -> { });
-        final EffectHandler<FileSystemException> handler = Maybe.fromRunnable(throwingOp);
+        final EffectHandler<FileSystemException> handler = Maybe.fromEffect(throwingOp);
 
         handler.orElse(consumerSpy);
         handler.orElse(runnableSpy);
@@ -216,7 +216,7 @@ import org.junit.jupiter.api.Test;
       @Test void never_calls_the_effect_callback() {
         final Consumer<RuntimeException> consumerSpy = spyLambda(e -> { });
         final Runnable runnableSpy = spyLambda(() -> { });
-        final EffectHandler<RuntimeException> handler = Maybe.fromRunnable(noOp);
+        final EffectHandler<RuntimeException> handler = Maybe.fromEffect(noOp);
 
         handler.orElse(consumerSpy);
         handler.orElse(runnableSpy);
@@ -232,7 +232,7 @@ import org.junit.jupiter.api.Test;
       @Test void throws_the_error() {
         final RuntimeException anotherError = new RuntimeException("OTHER");
         final Function<FileSystemException, RuntimeException> functionSpy = spyLambda(err -> anotherError);
-        final EffectHandler<FileSystemException> handler = Maybe.fromRunnable(throwingOp);
+        final EffectHandler<FileSystemException> handler = Maybe.fromEffect(throwingOp);
 
         assertThatThrownBy(handler::orThrow).isEqualTo(FAIL_EXCEPTION);
         assertThatThrownBy(() -> handler.orThrow(functionSpy)).isEqualTo(anotherError);
@@ -244,7 +244,7 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_error_is_NOT_present {
       @Test void no_exception_is_thrown() {
         final Function<RuntimeException, FileSystemException> functionSpy = spyLambda(err -> FAIL_EXCEPTION);
-        final EffectHandler<RuntimeException> handler = Maybe.fromRunnable(noOp);
+        final EffectHandler<RuntimeException> handler = Maybe.fromEffect(noOp);
 
         assertThatCode(handler::orThrow).doesNotThrowAnyException();
         assertThatCode(() -> handler.orThrow(functionSpy)).doesNotThrowAnyException();
@@ -256,7 +256,7 @@ import org.junit.jupiter.api.Test;
 
   @Nested class toMaybe {
     @Test void returns_a_maybe_with_nothing() {
-      assertThat(Maybe.fromRunnable(throwingOp).toMaybe().value())
+      assertThat(Maybe.fromEffect(throwingOp).toMaybe().value())
         .isEmpty();
     }
   }

--- a/src/test/java/com/github/joselion/maybe/ResolveHandlerTest.java
+++ b/src/test/java/com/github/joselion/maybe/ResolveHandlerTest.java
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.Test;
         final Consumer<String> consumerSpy = spyLambda(v -> { });
         final Runnable runnableSpy = spyLambda(() -> { });
 
-        Maybe.fromSupplier(okOp)
+        Maybe.fromResolver(okOp)
           .doOnSuccess(consumerSpy)
           .doOnSuccess(runnableSpy);
 
@@ -60,7 +60,7 @@ import org.junit.jupiter.api.Test;
         final Consumer<String> consumerSpy = spyLambda(v -> { });
         final Runnable runnableSpy = spyLambda(() -> { });
 
-        Maybe.fromSupplier(throwingOp)
+        Maybe.fromResolver(throwingOp)
           .doOnSuccess(consumerSpy)
           .doOnSuccess(runnableSpy);
 
@@ -78,7 +78,7 @@ import org.junit.jupiter.api.Test;
             final Consumer<FileSystemException> consumerSpy = spyLambda(error -> { });
             final Runnable runnableSpy = spyLambda(() -> { });
 
-            Maybe.fromSupplier(throwingOp)
+            Maybe.fromResolver(throwingOp)
               .doOnError(FileSystemException.class, consumerSpy)
               .doOnError(FileSystemException.class, runnableSpy);
 
@@ -92,7 +92,7 @@ import org.junit.jupiter.api.Test;
             final Consumer<RuntimeException> consumerSpy = spyLambda(error -> { });
             final Runnable runnableSpy = spyLambda(() -> { });
 
-            Maybe.fromSupplier(throwingOp)
+            Maybe.fromResolver(throwingOp)
               .doOnError(RuntimeException.class, consumerSpy)
               .doOnError(RuntimeException.class, runnableSpy);
 
@@ -107,7 +107,7 @@ import org.junit.jupiter.api.Test;
           final Consumer<FileSystemException> consumerSpy = spyLambda(error -> { });
           final Runnable runnableSpy = spyLambda(() -> { });
 
-          Maybe.fromSupplier(throwingOp)
+          Maybe.fromResolver(throwingOp)
             .doOnError(consumerSpy)
             .doOnError(runnableSpy);
 
@@ -122,7 +122,7 @@ import org.junit.jupiter.api.Test;
         final Consumer<RuntimeException> cunsumerSpy = spyLambda(error -> { });
         final Runnable runnableSpy = spyLambda(() -> { });
 
-        Maybe.fromSupplier(okOp)
+        Maybe.fromResolver(okOp)
           .doOnError(RuntimeException.class, cunsumerSpy)
           .doOnError(RuntimeException.class, runnableSpy)
           .doOnError(cunsumerSpy)
@@ -142,8 +142,8 @@ import org.junit.jupiter.api.Test;
             final Function<FileSystemException, String> functionSpy = spyLambda(e -> OK);
             final Supplier<String> supplierSpy = spyLambda(() -> OK);
             final List<ResolveHandler<String, FileSystemException>> handlers = List.of(
-              Maybe.fromSupplier(throwingOp).catchError(FileSystemException.class, functionSpy),
-              Maybe.fromSupplier(throwingOp).catchError(FileSystemException.class, supplierSpy)
+              Maybe.fromResolver(throwingOp).catchError(FileSystemException.class, functionSpy),
+              Maybe.fromResolver(throwingOp).catchError(FileSystemException.class, supplierSpy)
             );
 
             assertThat(handlers).isNotEmpty().allSatisfy(handler -> {
@@ -161,8 +161,8 @@ import org.junit.jupiter.api.Test;
             final Function<AccessDeniedException, String> functionSpy = spyLambda(e -> OK);
             final Supplier<String> supplierSpy = spyLambda(() -> OK);
             final List<ResolveHandler<String, FileSystemException>> handlers = List.of(
-              Maybe.fromSupplier(throwingOp).catchError(AccessDeniedException.class, functionSpy),
-              Maybe.fromSupplier(throwingOp).catchError(AccessDeniedException.class, supplierSpy)
+              Maybe.fromResolver(throwingOp).catchError(AccessDeniedException.class, functionSpy),
+              Maybe.fromResolver(throwingOp).catchError(AccessDeniedException.class, supplierSpy)
             );
 
             assertThat(handlers).isNotEmpty().allSatisfy(handler -> {
@@ -181,8 +181,8 @@ import org.junit.jupiter.api.Test;
           final Function<FileSystemException, String> handlerSpy = spyLambda(e -> OK);
           final Supplier<String> supplierSpy = spyLambda(() -> OK);
           final List<ResolveHandler<String, FileSystemException>> resolvers = List.of(
-            Maybe.fromSupplier(throwingOp).catchError(handlerSpy),
-            Maybe.fromSupplier(throwingOp).catchError(supplierSpy)
+            Maybe.fromResolver(throwingOp).catchError(handlerSpy),
+            Maybe.fromResolver(throwingOp).catchError(supplierSpy)
           );
 
           assertThat(resolvers).isNotEmpty().allSatisfy(resolver -> {
@@ -201,10 +201,10 @@ import org.junit.jupiter.api.Test;
         final Function<RuntimeException, String> functionSpy = spyLambda(e -> OK);
         final Supplier<String> supplierSpy = spyLambda(() -> OK);
         final List<ResolveHandler<String, RuntimeException>> resolvers = List.of(
-          Maybe.fromSupplier(okOp).catchError(RuntimeException.class, functionSpy),
-          Maybe.fromSupplier(okOp).catchError(RuntimeException.class, supplierSpy),
-          Maybe.fromSupplier(okOp).catchError(functionSpy),
-          Maybe.fromSupplier(okOp).catchError(supplierSpy)
+          Maybe.fromResolver(okOp).catchError(RuntimeException.class, functionSpy),
+          Maybe.fromResolver(okOp).catchError(RuntimeException.class, supplierSpy),
+          Maybe.fromResolver(okOp).catchError(functionSpy),
+          Maybe.fromResolver(okOp).catchError(supplierSpy)
         );
 
         assertThat(resolvers).isNotEmpty().allSatisfy(resolver -> {
@@ -350,7 +350,7 @@ import org.junit.jupiter.api.Test;
   @Nested class orElse {
     @Nested class when_the_value_is_present {
       @Test void returns_the_value() {
-        final ResolveHandler<String, ?> handler = Maybe.fromSupplier(okOp);
+        final ResolveHandler<String, ?> handler = Maybe.fromResolver(okOp);
 
         assertThat(handler.orElse(OTHER)).isEqualTo(OK);
         assertThat(handler.orElse(Exception::getMessage)).isEqualTo(OK);
@@ -360,7 +360,7 @@ import org.junit.jupiter.api.Test;
 
     @Nested class when_the_value_is_NOT_present {
       @Test void returns_the_default_value() {
-        final ResolveHandler<String, FileSystemException> handler = Maybe.fromSupplier(throwingOp);
+        final ResolveHandler<String, FileSystemException> handler = Maybe.fromResolver(throwingOp);
 
         assertThat(handler.orElse(OTHER)).isEqualTo(OTHER);
         assertThat(handler.orElse(FileSystemException::getMessage)).isEqualTo(FAIL_EXCEPTION.getMessage());
@@ -373,7 +373,7 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_value_is_present {
       @Test void returns_the_value() throws FileSystemException {
         final Function<RuntimeException, FileSystemException> functionSpy = spyLambda(error -> FAIL_EXCEPTION);
-        final ResolveHandler<String, RuntimeException> handler = Maybe.fromSupplier(okOp);
+        final ResolveHandler<String, RuntimeException> handler = Maybe.fromResolver(okOp);
 
         assertThat(handler.orThrow()).isEqualTo(OK);
         assertThat(handler.orThrow(functionSpy)).isEqualTo(OK);
@@ -386,7 +386,7 @@ import org.junit.jupiter.api.Test;
       @Test void throws_the_error() {
         final RuntimeException anotherError = new RuntimeException(OTHER);
         final Function<FileSystemException, RuntimeException> functionSpy = spyLambda(error -> anotherError);
-        final ResolveHandler<?, FileSystemException> handler = Maybe.fromSupplier(throwingOp);
+        final ResolveHandler<?, FileSystemException> handler = Maybe.fromResolver(throwingOp);
 
         assertThatThrownBy(handler::orThrow).isEqualTo(FAIL_EXCEPTION);
         assertThatThrownBy(() -> handler.orThrow(functionSpy)).isEqualTo(anotherError);
@@ -399,14 +399,14 @@ import org.junit.jupiter.api.Test;
   @Nested class toMaybe {
     @Nested class when_the_value_is_present {
       @Test void returns_a_maybe_with_the_value() {
-        assertThat(Maybe.fromSupplier(okOp).toMaybe().value())
+        assertThat(Maybe.fromResolver(okOp).toMaybe().value())
           .contains(OK);
       }
     }
 
     @Nested class when_the_value_is_NOT_present {
       @Test void returns_a_maybe_with_nothing() {
-        assertThat(Maybe.fromSupplier(throwingOp).toMaybe().value())
+        assertThat(Maybe.fromResolver(throwingOp).toMaybe().value())
           .isEmpty();
       }
     }
@@ -415,13 +415,13 @@ import org.junit.jupiter.api.Test;
   @Nested class toOptional {
     @Nested class when_the_value_is_present {
       @Test void returns_the_value_wrapped_in_an_optinal() {
-        assertThat(Maybe.fromSupplier(okOp).toOptional()).contains(OK);
+        assertThat(Maybe.fromResolver(okOp).toOptional()).contains(OK);
       }
     }
 
     @Nested class when_the_value_is_NOT_present {
       @Test void returns_an_empty_optional() {
-        assertThat(Maybe.fromSupplier(throwingOp).toOptional()).isEmpty();
+        assertThat(Maybe.fromResolver(throwingOp).toOptional()).isEmpty();
       }
     }
   }

--- a/src/test/java/com/github/joselion/maybe/ResourceHolderTest.java
+++ b/src/test/java/com/github/joselion/maybe/ResourceHolderTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
     }
 
     @Nested class when_the_resource_is_present {
-      @Nested class when_the_operation_success {
+      @Nested class when_the_operation_succeeds {
         @Test void returns_a_handler_with_the_value() {
           final FileInputStream fis = getFIS();
           final ResolveHandler<String, ?> handler = Maybe.withResource(fis)
@@ -86,7 +86,7 @@ import org.junit.jupiter.api.Test;
     }
 
     @Nested class when_the_resource_is_present {
-      @Nested class when_the_operation_success {
+      @Nested class when_the_operation_succeeds {
         @Test void returns_a_handler_with_nothing() {
           final List<Integer> counter = new ArrayList<>();
           final FileInputStream fis = getFIS();


### PR DESCRIPTION
* Rename `.fromSupplier(..)` → `.fromResolver(..)`
* Rename `.fromRunnable(..)` -> `.fromEffect(..)`
* Add partial implementation overloads to `.fromResolver(..)` and `.fromEffect(..)`