### PR TITLE
Lazy orElse rework

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,10 @@ javadoc {
   }
 
   title = 'Maybe - Safely handle exceptions'
-  options.addStringOption('Xwerror', '-quiet')
+  options {
+    addStringOption('Xwerror', '-quiet')
+    tags('apiNote')
+  }
 }
 
 jar {

--- a/src/main/java/com/github/joselion/maybe/ResolveHandler.java
+++ b/src/main/java/com/github/joselion/maybe/ResolveHandler.java
@@ -377,12 +377,15 @@ public final class ResolveHandler<T, E extends Exception> {
    * Returns the resolved value if present. Otherwise, the result produced by
    * the supplying function as another value.
    *
+   * @apiNote Use this method instead of {@link #orElse(Object)} to do lazy
+   *          evaluation of the produced value. That means that the "else"
+   *          value won't be evaluated if the error is not present.
    * @param supplier the supplying function that produces another value if the
    *                 opration failed to resolve
    * @return the resolved value if present. Another value otherwise
    */
-  public T orElse(final Supplier<T> supplier) {
-    return success.orElseGet(supplier::get);
+  public T orElseGet(final Supplier<T> supplier) {
+    return success.orElseGet(supplier);
   }
 
   /**

--- a/src/test/java/com/github/joselion/maybe/ResolveHandlerTest.java
+++ b/src/test/java/com/github/joselion/maybe/ResolveHandlerTest.java
@@ -406,7 +406,6 @@ import org.junit.jupiter.api.Test;
 
         assertThat(handler.orElse(OTHER)).isEqualTo(OK);
         assertThat(handler.orElse(Exception::getMessage)).isEqualTo(OK);
-        assertThat(handler.orElse(() -> OTHER)).isEqualTo(OK);
       }
     }
 
@@ -416,7 +415,30 @@ import org.junit.jupiter.api.Test;
 
         assertThat(handler.orElse(OTHER)).isEqualTo(OTHER);
         assertThat(handler.orElse(FileSystemException::getMessage)).isEqualTo(FAIL_EXCEPTION.getMessage());
-        assertThat(handler.orElse(() -> OTHER)).isEqualTo(OTHER);
+      }
+    }
+  }
+
+  @Nested class orElseGet {
+    @Nested class when_the_value_is_present {
+      @Test void never_evaluates_the_supplier_and_returns_the_value() {
+        final Supplier<String> supplierSpy = spyLambda(() -> OTHER);
+        final ResolveHandler<String, ?> handler = Maybe.fromResolver(okOp);
+
+        assertThat(handler.orElseGet(supplierSpy)).isEqualTo(OK);
+
+        verify(supplierSpy, never()).get();
+      }
+    }
+
+    @Nested class when_the_value_is_NOT_present {
+      @Test void evaluates_the_supplier_and_returns_the_produced_value() {
+        final Supplier<String> supplierSpy = spyLambda(() -> OTHER);
+        final ResolveHandler<String, FileSystemException> handler = Maybe.fromResolver(throwingOp);
+
+        assertThat(handler.orElseGet(supplierSpy)).isEqualTo(OTHER);
+
+        verify(supplierSpy, times(1)).get();
       }
     }
   }


### PR DESCRIPTION
Rename `.orElse(Supplier)` overload to `.OrElseGet(Supplier)` to prevent ambiguity