### PR TITLE
Fix ambiguity issues

### DIFF
--- a/src/main/java/com/github/joselion/maybe/EffectHandler.java
+++ b/src/main/java/com/github/joselion/maybe/EffectHandler.java
@@ -88,19 +88,6 @@ public final class EffectHandler<E extends Exception> {
   }
 
   /**
-   * Run an effect if the error is present and is an instance of the provided
-   * type.
-   *
-   * @param <X> the type of the error to match
-   * @param ofType a class instance of the error type to match
-   * @param effect a runnable function
-   * @return the same handler to continue chainning operations
-   */
-  public <X extends Exception> EffectHandler<E> doOnError(final Class<X> ofType, final Runnable effect) {
-    return this.doOnError(ofType, caught -> effect.run());
-  }
-
-  /**
    * Run an effect if the error is present. The error is passed in the argument
    * of the {@code effect} consumer.
    * 
@@ -111,16 +98,6 @@ public final class EffectHandler<E extends Exception> {
     error.ifPresent(effect);
 
     return this;
-  }
-
-  /**
-   * Run an effect if an error is present.
-   *
-   * @param effect a runnable function
-   * @return the same handler to continue chainning operations
-   */
-  public EffectHandler<E> doOnError(final Runnable effect) {
-    return this.doOnError(caught -> effect.run());
   }
 
   /**
@@ -145,20 +122,6 @@ public final class EffectHandler<E extends Exception> {
   }
 
   /**
-   * Catch the error if is present and is an instance of the provided type.
-   * Assuming the error was handled returns a handler with {@code nothing}.
-   * 
-   * @param <X> the type of the error to catch
-   * @param ofType a class instance of the error type to catch
-   * @param handler a runnable function
-   * @return a handler with nothing if an error instance of the provided type
-   *         was caught. The same handler instance otherwise
-   */
-  public <X extends E> EffectHandler<E> catchError(final Class<X> ofType, final Runnable handler) {
-    return this.catchError(ofType, caught -> handler.run());
-  }
-
-  /**
    * Catch the error if is present. Assuming the error was handled returns a
    * handler with {@code nothing}. The caught error is passed in the argument
    * of the {@code handler} consumer.
@@ -176,18 +139,6 @@ public final class EffectHandler<E extends Exception> {
   }
 
   /**
-   * Catch the error if is present. Assuming the error was handled returns a
-   * handler with {@code nothing}.
-   *
-   * @param handler a runnable function
-   * @return a handler with nothing if an error instance of the provided type
-   *         was caught. The same handler instance otherwise
-   */
-  public EffectHandler<E> catchError(final Runnable handler) {
-    return this.catchError(caught -> handler.run());
-  }
-
-  /**
    * Terminal operation to handle the error if present. The error is passed in
    * the argument of the {@code effect} consumer.
    *
@@ -195,15 +146,6 @@ public final class EffectHandler<E extends Exception> {
    */
   public void orElse(final Consumer<E> effect) {
     error.ifPresent(effect);
-  }
-
-  /**
-   * Terminal operation to handle the error if present.
-   *
-   * @param effect a runnable function
-   */
-  public void orElse(final Runnable effect) {
-    this.orElse(caught -> effect.run());
   }
 
   /**

--- a/src/main/java/com/github/joselion/maybe/Maybe.java
+++ b/src/main/java/com/github/joselion/maybe/Maybe.java
@@ -104,38 +104,6 @@ public final class Maybe<T> {
   }
 
   /**
-   * Convenience partial application of a {@code resolver}. This method creates
-   * a function that receives any external value of type {@code S}, and produces
-   * a {@link ResolveHandler} once applied. This is specially useful when we
-   * want to create a {@link Maybe} from a callback argument, like on a
-   * {@link Optional#map(Function)} for instance.
-   * <p>For example, the following code:
-   * <pre>
-   *  Optional.of(value)
-   *    .map(str -> Maybe.fromResolver(() -> decode(str)));
-   * </pre>
-   * Is equivalent to:
-   * <pre>
-   *  Optional.of(value)
-   *    .map(Maybe.fromResolver(this::decode));
-   * </pre>
-   *
-   * @param <S> the external value type
-   * @param <T> the type of the value to be resolved
-   * @param <E> the type of the error the resolver may throw
-   * @param resolver a checked function that receives an external value
-   *                 {@code S} and produces a value {@code T}
-   * @return a partially applied {@link ResolveHandler}. That is, a function
-   *         that receives an external value {@code S}, and produces a new
-   *         handler {@code ResolveHandler<T, E>}
-   */
-  public static <S, T, E extends Exception> Function<S, ResolveHandler<T, E>> fromResolver(
-    final FunctionChecked<S, T, E> resolver
-  ) {
-    return injected -> Maybe.fromResolver(() -> resolver.apply(injected));
-  }
-
-  /**
    * Runs an effect that may throw an exception using a {@link RunnableChecked}
    * expression. Returning then an {@link EffectHandler} which allows to handle
    * the possible error.
@@ -158,33 +126,65 @@ public final class Maybe<T> {
   }
 
   /**
+   * Convenience partial application of a {@code resolver}. This method creates
+   * a function that receives an {@code S} value which can be used to produce a
+   * {@link ResolveHandler} once applied. This is specially useful when we want
+   * to create a {@link Maybe} from a callback argument, like on a
+   * {@link Optional#map(Function)} for instance.
+   * <p>
+   * In other words, the following code
+   * <pre>
+   *  Optional.of(value)
+   *    .map(str -> Maybe.fromResolver(() -> decode(str)));
+   * </pre>
+   * Is equivalent to
+   * <pre>
+   *  Optional.of(value)
+   *    .map(Maybe.partialResolver(this::decode));
+   * </pre>
+   *
+   * @param <S> the type of the value the returned function receives
+   * @param <T> the type of the value to be resolved
+   * @param <E> the type of the error the resolver may throw
+   * @param resolver a checked function that receives an {@code S} value and
+   *                 returns a {@code T} value
+   * @return a partially applied {@link ResolveHandler}. This means, a function
+   *         that receives an {@code S} value, and produces a {@code ResolveHandler<T, E>}
+   */
+  public static <S, T, E extends Exception> Function<S, ResolveHandler<T, E>> partialResolver(
+    final FunctionChecked<S, T, E> resolver
+  ) {
+    return value -> Maybe.fromResolver(() -> resolver.apply(value));
+  }
+
+  /**
    * Convenience partial application of an {@code effect}. This method creates
-   * a function that receives any external value of type {@code S}, and produces
-   * a {@link EffectHandler} once applied. This is specially useful when we
+   * a function that receives an {@code S} value which can be used to produce
+   * an {@link EffectHandler} once applied. This is specially useful when we
    * want to create a {@link Maybe} from a callback argument, like on a
    * {@link Optional#map(Function)} for instance.
-   * <p>For example, the following code:
+   * <p>
+   * In other words, the following code
    * <pre>
    *  Optional.of(value)
    *    .map(msg -> Maybe.fromEffect(() -> sendMessage(msg)));
    * </pre>
-   * Is equivalent to:
+   * Is equivalent to
    * <pre>
    *  Optional.of(value)
-   *    .map(Maybe.fromEffect(this::sendMessage));
+   *    .map(Maybe.partialEffect(this::sendMessage));
    * </pre>
    *
-   * @param <S> the external value type
+   * @param <S> the type of the value the returned function receives
    * @param <E> the type of the error the resolver may throw
-   * @param effect a checked consumer that receives an external value {@code S}
-   * @return a partially applied {@link EffectHandler}. That is, a function
-   *         that receives an external value {@code S}, and produces a new
-   *         handler {@code EffectHandler<E>}
+   * @param effect a checked consumer that receives an {@code S} value
+   * @return a partially applied {@link EffectHandler}. This means, a function
+   *         that receives an {@code S} value, and produces an {@code EffectHandler<E>}
    */
-  public static <S, E extends Exception> Function<S, EffectHandler<E>> fromEffect(
+  public static <S, E extends Exception> Function<S, EffectHandler<E>> partialEffect(
     final ConsumerChecked<S, E> effect
   ) {
-    return injected -> Maybe.fromEffect(() -> effect.accept(injected));
+    return value -> Maybe.fromEffect(() -> effect.accept(value));
   }
 
   /**

--- a/src/main/java/com/github/joselion/maybe/ResolveHandler.java
+++ b/src/main/java/com/github/joselion/maybe/ResolveHandler.java
@@ -102,16 +102,6 @@ public final class ResolveHandler<T, E extends Exception> {
   }
 
   /**
-   * Run an effect if the operation resolved successfully.
-   *
-   * @param effect a runnable function
-   * @return the same handler to continue chainning operations
-   */
-  public ResolveHandler<T, E> doOnSuccess(final Runnable effect) {
-    return this.doOnSuccess(resolved -> effect.run());
-  }
-
-  /**
    * Run an effect if the error is present and is an instance of the provided
    * type. The error is passed in the argument of the {@code effect}
    * consumer.
@@ -130,19 +120,6 @@ public final class ResolveHandler<T, E extends Exception> {
   }
 
   /**
-   * Run an effect if the error is present and is an instance of the provided
-   * type.
-   *
-   * @param <X> the type of the error to match
-   * @param ofType a class instance of the error type to match
-   * @param effect a runnable function
-   * @return the same handler to continue chainning operations
-   */
-  public <X extends Exception> ResolveHandler<T, E> doOnError(final Class<X> ofType, final Runnable effect) {
-    return this.doOnError(ofType, caught -> effect.run());
-  }
-
-  /**
    * Run an effect if the error is present. The error is passed in the argument
    * of the {@code effect} consumer.
    * 
@@ -153,16 +130,6 @@ public final class ResolveHandler<T, E extends Exception> {
     error.ifPresent(effect);
 
     return this;
-  }
-
-  /**
-   * Run an effect if an error is present.
-   *
-   * @param effect a runnable function
-   * @return the same handler to continue chainning operations
-   */
-  public ResolveHandler<T, E> doOnError(final Runnable effect) {
-    return this.doOnError(caught -> effect.run());
   }
 
   /**
@@ -186,20 +153,6 @@ public final class ResolveHandler<T, E extends Exception> {
   }
 
   /**
-   * Catch the error if is present and is an instance of the provided type.
-   * Then handle the error and return a new value.
-   *
-   * @param <X> the type of the error to catch
-   * @param ofType a class instance of the error type to catch
-   * @param handler a supplier function that produces another value
-   * @return a handler containing a new value if an error instance of the
-   *         provided type was caught. The same handler instance otherwise
-   */
-  public <X extends E> ResolveHandler<T, E> catchError(final Class<X> ofType, final Supplier<T> handler) {
-    return this.catchError(ofType, caught -> handler.get());
-  }
-
-  /**
    * Catch the error if is present and handle it to return a new value. The
    * caught error is passed in the argument of the {@code handler} function.
    *
@@ -212,18 +165,6 @@ public final class ResolveHandler<T, E extends Exception> {
     return error.map(handler::apply)
       .map(ResolveHandler::<T, E>withSuccess)
       .orElse(this);
-  }
-
-  /**
-   * Catch the error if is present and handle it to return a new value through
-   * the supplier function.
-   *
-   * @param supplier a supplier function that produces another value
-   * @return a handler containing a new value if an error was caught. The same
-   *         handler instance otherwise
-   */
-  public ResolveHandler<T, E> catchError(final Supplier<T> supplier) {
-    return catchError(caught -> supplier.get());
   }
 
   /**
@@ -265,7 +206,7 @@ public final class ResolveHandler<T, E extends Exception> {
     final FunctionChecked<T, S, X> successResolver,
     final FunctionChecked<E, S, X> errorResolver
   ) {
-    return error.map(Maybe.fromResolver(errorResolver))
+    return error.map(Maybe.partialResolver(errorResolver))
       .orElseGet(() -> this.resolve(successResolver));
   }
 

--- a/src/test/java/com/github/joselion/maybe/EffectHandlerTest.java
+++ b/src/test/java/com/github/joselion/maybe/EffectHandlerTest.java
@@ -59,28 +59,22 @@ import org.junit.jupiter.api.Test;
         @Nested class and_the_error_is_an_instance_of_the_provided_type {
           @Test void calls_the_effect_callback() {
             final Consumer<FileSystemException> consumerSpy = spyLambda(error -> { });
-            final Runnable runnableSpy = spyLambda(() -> { });
 
             Maybe.fromEffect(throwingOp)
-              .doOnError(FileSystemException.class, consumerSpy)
-              .doOnError(FileSystemException.class, runnableSpy);
+              .doOnError(FileSystemException.class, consumerSpy);
 
             verify(consumerSpy, times(1)).accept(FAIL_EXCEPTION);
-            verify(runnableSpy, times(1)).run();;
           }
         }
 
         @Nested class and_the_error_is_NOT_an_instance_of_the_provided_type {
           @Test void never_calls_the_effect_callback() {
             final Consumer<RuntimeException> consumerSpy = spyLambda(error -> { });
-            final Runnable runnableSpy = spyLambda(() -> { });
 
             Maybe.fromEffect(throwingOp)
-              .doOnError(RuntimeException.class, consumerSpy)
-              .doOnError(RuntimeException.class, runnableSpy);
+              .doOnError(RuntimeException.class, consumerSpy);
 
             verify(consumerSpy, never()).accept(any());
-            verify(runnableSpy, never()).run();
           }
         }
       }
@@ -88,14 +82,11 @@ import org.junit.jupiter.api.Test;
       @Nested class and_the_error_type_is_NOT_provided {
         @Test void calls_the_effect_callback() {
           final Consumer<FileSystemException> consumerSpy = spyLambda(error -> { });
-          final Runnable runnableSpy = spyLambda(() -> { });
 
           Maybe.fromEffect(throwingOp)
-            .doOnError(consumerSpy)
-            .doOnError(runnableSpy);
+            .doOnError(consumerSpy);
 
           verify(consumerSpy, times(1)).accept(FAIL_EXCEPTION);
-          verify(runnableSpy, times(1)).run();
         }
       }
     }
@@ -103,16 +94,12 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_error_is_NOT_present {
       @Test void never_calls_the_effect_callback() {
         final Consumer<RuntimeException> cunsumerSpy = spyLambda(error -> { });
-        final Runnable runnableSpy = spyLambda(() -> { });
 
         Maybe.fromEffect(noOp)
           .doOnError(RuntimeException.class, cunsumerSpy)
-          .doOnError(RuntimeException.class, runnableSpy)
-          .doOnError(cunsumerSpy)
-          .doOnError(runnableSpy);
+          .doOnError(cunsumerSpy);
 
         verify(cunsumerSpy, never()).accept(any());
-        verify(runnableSpy, never()).run();
       }
     }
   }
@@ -123,36 +110,24 @@ import org.junit.jupiter.api.Test;
         @Nested class and_the_error_is_an_instance_of_the_provided_type {
           @Test void calls_the_handler_function() {
             final Consumer<FileSystemException> consumerSpy = spyLambda(e -> { });
-            final Runnable runnableSpy = spyLambda(() -> { });
-            final List<EffectHandler<FileSystemException>> handlers = List.of(
-              Maybe.fromEffect(throwingOp).catchError(FileSystemException.class, consumerSpy),
-              Maybe.fromEffect(throwingOp).catchError(FileSystemException.class, runnableSpy)
-            );
+            final EffectHandler<FileSystemException> handler = Maybe.fromEffect(throwingOp)
+              .catchError(FileSystemException.class, consumerSpy);
 
-            assertThat(handlers).isNotEmpty().allSatisfy(handler -> {
-              assertThat(handler.error()).isEmpty();
-            });
+            assertThat(handler.error()).isEmpty();
 
             verify(consumerSpy, times(1)).accept(FAIL_EXCEPTION);
-            verify(runnableSpy, times(1)).run();
           }
         }
 
         @Nested class and_the_error_is_NOT_an_instance_of_the_provided_type {
           @Test void never_calls_the_handler_function() {
             final Consumer<AccessDeniedException> consumerSpy = spyLambda(e -> { });
-            final Runnable runnableSpy = spyLambda(() -> { });
-            final List<EffectHandler<FileSystemException>> handlers = List.of(
-              Maybe.fromEffect(throwingOp).catchError(AccessDeniedException.class, consumerSpy),
-              Maybe.fromEffect(throwingOp).catchError(AccessDeniedException.class, runnableSpy)
-            );
+            final EffectHandler<FileSystemException> handler = Maybe.fromEffect(throwingOp)
+              .catchError(AccessDeniedException.class, consumerSpy);
 
-            assertThat(handlers).isNotEmpty().allSatisfy(handler -> {
-              assertThat(handler.error()).contains(FAIL_EXCEPTION);
-            });
+            assertThat(handler.error()).contains(FAIL_EXCEPTION);
 
             verify(consumerSpy, never()).accept(any());
-            verify(runnableSpy, never()).run();
           }
         }
       }
@@ -160,18 +135,12 @@ import org.junit.jupiter.api.Test;
       @Nested class and_the_error_type_is_NOT_provided {
         @Test void calls_the_handler_function() {
           final Consumer<FileSystemException> consumerSpy = spyLambda(e -> { });
-          final Runnable runnableSpy = spyLambda(() -> { });
-          final List<EffectHandler<FileSystemException>> handlers = List.of(
-            Maybe.fromEffect(throwingOp).catchError(consumerSpy),
-            Maybe.fromEffect(throwingOp).catchError(runnableSpy)
-          );
+          final EffectHandler<FileSystemException> handler = Maybe.fromEffect(throwingOp)
+            .catchError(consumerSpy);
 
-          assertThat(handlers).isNotEmpty().allSatisfy(handler -> {
-            assertThat(handler.error()).isEmpty();
-          });
+          assertThat(handler.error()).isEmpty();
 
           verify(consumerSpy, times(1)).accept(FAIL_EXCEPTION);
-          verify(runnableSpy, times(1)).run();
         }
       }
     }
@@ -179,12 +148,9 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_error_is_NOT_present {
       @Test void never_calls_the_handler_function() {
         final Consumer<RuntimeException> consumerSpy = spyLambda(e -> { });
-        final Runnable runnableSpy = spyLambda(() -> { });
         final List<EffectHandler<RuntimeException>> handlers = List.of(
           Maybe.fromEffect(noOp).catchError(RuntimeException.class, consumerSpy),
-          Maybe.fromEffect(noOp).catchError(RuntimeException.class, runnableSpy),
-          Maybe.fromEffect(noOp).catchError(consumerSpy),
-          Maybe.fromEffect(noOp).catchError(runnableSpy)
+          Maybe.fromEffect(noOp).catchError(consumerSpy)
         );
 
         assertThat(handlers).isNotEmpty().allSatisfy(handler -> {
@@ -192,7 +158,6 @@ import org.junit.jupiter.api.Test;
         });
 
         verify(consumerSpy, never()).accept(any());
-        verify(runnableSpy, never()).run();
       }
     }
   }
@@ -201,28 +166,22 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_error_is_present {
       @Test void calls_the_effect_callback() {
         final Consumer<FileSystemException> consumerSpy = spyLambda(e -> { });
-        final Runnable runnableSpy = spyLambda(() -> { });
         final EffectHandler<FileSystemException> handler = Maybe.fromEffect(throwingOp);
 
         handler.orElse(consumerSpy);
-        handler.orElse(runnableSpy);
 
         verify(consumerSpy, times(1)).accept(FAIL_EXCEPTION);
-        verify(runnableSpy, times(1)).run();
       }
     }
 
     @Nested class when_the_error_is_NOT_present {
       @Test void never_calls_the_effect_callback() {
         final Consumer<RuntimeException> consumerSpy = spyLambda(e -> { });
-        final Runnable runnableSpy = spyLambda(() -> { });
         final EffectHandler<RuntimeException> handler = Maybe.fromEffect(noOp);
 
         handler.orElse(consumerSpy);
-        handler.orElse(runnableSpy);
 
         verify(consumerSpy, never()).accept(any());
-        verify(runnableSpy, never()).run();
       }
     }
   }

--- a/src/test/java/com/github/joselion/maybe/ResolveHandlerTest.java
+++ b/src/test/java/com/github/joselion/maybe/ResolveHandlerTest.java
@@ -45,28 +45,22 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_value_is_present {
       @Test void calls_the_effect_callback() {
         final Consumer<String> consumerSpy = spyLambda(v -> { });
-        final Runnable runnableSpy = spyLambda(() -> { });
 
         Maybe.fromResolver(okOp)
-          .doOnSuccess(consumerSpy)
-          .doOnSuccess(runnableSpy);
+          .doOnSuccess(consumerSpy);
 
         verify(consumerSpy, times(1)).accept(OK);
-        verify(runnableSpy, times(1)).run();
       }
     }
 
     @Nested class when_the_value_is_NOT_present {
       @Test void never_calls_the_effect_callback() {
         final Consumer<String> consumerSpy = spyLambda(v -> { });
-        final Runnable runnableSpy = spyLambda(() -> { });
 
         Maybe.fromResolver(throwingOp)
-          .doOnSuccess(consumerSpy)
-          .doOnSuccess(runnableSpy);
+          .doOnSuccess(consumerSpy);
 
         verify(consumerSpy, never()).accept(any());
-        verify(runnableSpy, never()).run();
       }
     }
   }
@@ -77,28 +71,22 @@ import org.junit.jupiter.api.Test;
         @Nested class and_the_error_is_an_instance_of_the_provided_type {
           @Test void calls_the_effect_callback() {
             final Consumer<FileSystemException> consumerSpy = spyLambda(error -> { });
-            final Runnable runnableSpy = spyLambda(() -> { });
 
             Maybe.fromResolver(throwingOp)
-              .doOnError(FileSystemException.class, consumerSpy)
-              .doOnError(FileSystemException.class, runnableSpy);
+              .doOnError(FileSystemException.class, consumerSpy);
 
             verify(consumerSpy, times(1)).accept(FAIL_EXCEPTION);
-            verify(runnableSpy, times(1)).run();;
           }
         }
 
         @Nested class and_the_error_is_NOT_an_instance_of_the_provided_type {
           @Test void never_calls_the_effect_callback() {
             final Consumer<RuntimeException> consumerSpy = spyLambda(error -> { });
-            final Runnable runnableSpy = spyLambda(() -> { });
 
             Maybe.fromResolver(throwingOp)
-              .doOnError(RuntimeException.class, consumerSpy)
-              .doOnError(RuntimeException.class, runnableSpy);
+              .doOnError(RuntimeException.class, consumerSpy);
 
             verify(consumerSpy, never()).accept(any());
-            verify(runnableSpy, never()).run();
           }
         }
       }
@@ -106,14 +94,11 @@ import org.junit.jupiter.api.Test;
       @Nested class and_the_error_type_is_NOT_provided {
         @Test void calls_the_effect_callback() {
           final Consumer<FileSystemException> consumerSpy = spyLambda(error -> { });
-          final Runnable runnableSpy = spyLambda(() -> { });
 
           Maybe.fromResolver(throwingOp)
-            .doOnError(consumerSpy)
-            .doOnError(runnableSpy);
+            .doOnError(consumerSpy);
 
           verify(consumerSpy, times(1)).accept(FAIL_EXCEPTION);
-          verify(runnableSpy, times(1)).run();
         }
       }
     }
@@ -121,16 +106,12 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_error_is_NOT_present {
       @Test void never_calls_the_effect_callback() {
         final Consumer<RuntimeException> cunsumerSpy = spyLambda(error -> { });
-        final Runnable runnableSpy = spyLambda(() -> { });
 
         Maybe.fromResolver(okOp)
           .doOnError(RuntimeException.class, cunsumerSpy)
-          .doOnError(RuntimeException.class, runnableSpy)
-          .doOnError(cunsumerSpy)
-          .doOnError(runnableSpy);
+          .doOnError(cunsumerSpy);
 
         verify(cunsumerSpy, never()).accept(any());
-        verify(runnableSpy, never()).run();
       }
     }
   }
@@ -141,38 +122,26 @@ import org.junit.jupiter.api.Test;
         @Nested class and_the_error_is_an_instance_of_the_provided_type {
           @Test void calls_the_handler_function() {
             final Function<FileSystemException, String> functionSpy = spyLambda(e -> OK);
-            final Supplier<String> supplierSpy = spyLambda(() -> OK);
-            final List<ResolveHandler<String, FileSystemException>> handlers = List.of(
-              Maybe.fromResolver(throwingOp).catchError(FileSystemException.class, functionSpy),
-              Maybe.fromResolver(throwingOp).catchError(FileSystemException.class, supplierSpy)
-            );
+            final ResolveHandler<String, FileSystemException> handler = Maybe.fromResolver(throwingOp)
+              .catchError(FileSystemException.class, functionSpy);
 
-            assertThat(handlers).isNotEmpty().allSatisfy(handler -> {
-              assertThat(handler.success()).contains(OK);
-              assertThat(handler.error()).isEmpty();
-            });
+            assertThat(handler.success()).contains(OK);
+            assertThat(handler.error()).isEmpty();
 
             verify(functionSpy, times(1)).apply(FAIL_EXCEPTION);
-            verify(supplierSpy, times(1)).get();
           }
         }
 
         @Nested class and_the_error_is_NOT_an_instance_of_the_provided_type {
           @Test void never_calls_the_handler_function() {
             final Function<AccessDeniedException, String> functionSpy = spyLambda(e -> OK);
-            final Supplier<String> supplierSpy = spyLambda(() -> OK);
-            final List<ResolveHandler<String, FileSystemException>> handlers = List.of(
-              Maybe.fromResolver(throwingOp).catchError(AccessDeniedException.class, functionSpy),
-              Maybe.fromResolver(throwingOp).catchError(AccessDeniedException.class, supplierSpy)
-            );
+            final ResolveHandler<String, FileSystemException> handler = Maybe.fromResolver(throwingOp)
+              .catchError(AccessDeniedException.class, functionSpy);
 
-            assertThat(handlers).isNotEmpty().allSatisfy(handler -> {
-              assertThat(handler.success()).isEmpty();
-              assertThat(handler.error()).contains(FAIL_EXCEPTION);
-            });
+            assertThat(handler.success()).isEmpty();
+            assertThat(handler.error()).contains(FAIL_EXCEPTION);
 
             verify(functionSpy, never()).apply(any());
-            verify(supplierSpy, never()).get();
           }
         }
       }
@@ -180,19 +149,13 @@ import org.junit.jupiter.api.Test;
       @Nested class and_the_error_type_is_NOT_provided {
         @Test void calls_the_handler_function() {
           final Function<FileSystemException, String> handlerSpy = spyLambda(e -> OK);
-          final Supplier<String> supplierSpy = spyLambda(() -> OK);
-          final List<ResolveHandler<String, FileSystemException>> resolvers = List.of(
-            Maybe.fromResolver(throwingOp).catchError(handlerSpy),
-            Maybe.fromResolver(throwingOp).catchError(supplierSpy)
-          );
+          final ResolveHandler<String, FileSystemException> resolver = Maybe.fromResolver(throwingOp)
+            .catchError(handlerSpy);
 
-          assertThat(resolvers).isNotEmpty().allSatisfy(resolver -> {
-            assertThat(resolver.success()).contains(OK);
-            assertThat(resolver.error()).isEmpty();
-          });
+          assertThat(resolver.success()).contains(OK);
+          assertThat(resolver.error()).isEmpty();
 
           verify(handlerSpy, times(1)).apply(FAIL_EXCEPTION);
-          verify(supplierSpy, times(1)).get();
         }
       }
     }
@@ -200,12 +163,9 @@ import org.junit.jupiter.api.Test;
     @Nested class when_the_error_is_NOT_present {
       @Test void never_calls_the_handler_function() {
         final Function<RuntimeException, String> functionSpy = spyLambda(e -> OK);
-        final Supplier<String> supplierSpy = spyLambda(() -> OK);
         final List<ResolveHandler<String, RuntimeException>> resolvers = List.of(
           Maybe.fromResolver(okOp).catchError(RuntimeException.class, functionSpy),
-          Maybe.fromResolver(okOp).catchError(RuntimeException.class, supplierSpy),
-          Maybe.fromResolver(okOp).catchError(functionSpy),
-          Maybe.fromResolver(okOp).catchError(supplierSpy)
+          Maybe.fromResolver(okOp).catchError(functionSpy)
         );
 
         assertThat(resolvers).isNotEmpty().allSatisfy(resolver -> {
@@ -214,7 +174,6 @@ import org.junit.jupiter.api.Test;
         });
 
         verify(functionSpy, never()).apply(any());
-        verify(supplierSpy, never()).get();
       }
     }
   }


### PR DESCRIPTION
- Rename `.fromResolver(FunctionChecked)`→ `.partialResolver(FunctionChecked)`
- Rename `.fromEffect(ConsumerChecked)` → `.partialEffect(ConsumerChecked)`
- Remove potentially ambiguous overloads:
  - `ResolveHandler#doOnSuccess(Runnable)`
  - `ResolveHandler#doOnError(Class, Runnable)`
  - `ResolveHandler#doOnError(Runnable)`
  - `ResolveHandler#catchError(Class, Supplier)`
  - `ResolveHandler#catchError(Supplier)`
  - `EffectHandler#doOnError(Class, Runnable)`
  - `EffectHandler#doOnError(Runnable)`
  - `EffectHandler#catchError(Class, Runnable)`
  - `EffectHandler#catchError(Runnable)`
  - `EffectHandler#orElse(Runnable)`