### PR TITLE
fix(core): Extends generics from Throwable

### DIFF
--- a/src/main/java/io/github/joselion/maybe/EffectHandler.java
+++ b/src/main/java/io/github/joselion/maybe/EffectHandler.java
@@ -19,7 +19,7 @@ import io.github.joselion.maybe.util.function.ThrowingRunnable;
  * @author Jose Luis Leon
  * @since v0.3.2
  */
-public final class EffectHandler<E extends Exception> {
+public final class EffectHandler<E extends Throwable> {
 
   private final Optional<E> error;
 
@@ -34,7 +34,7 @@ public final class EffectHandler<E extends Exception> {
    * @param <E> the type of the possible exception
    * @return a EffectHandler with neither the success nor the error value
    */
-  static <E extends Exception> EffectHandler<E> empty() {
+  static <E extends Throwable> EffectHandler<E> empty() {
     return new EffectHandler<>(null);
   }
 
@@ -45,7 +45,7 @@ public final class EffectHandler<E extends Exception> {
    * @param error the error to instanciate the EffectHandler
    * @return a EffectHandler instance with an error value
    */
-  static <E extends Exception> EffectHandler<E> ofError(final E error) {
+  static <E extends Throwable> EffectHandler<E> ofError(final E error) {
     return new EffectHandler<>(error);
   }
 
@@ -82,7 +82,7 @@ public final class EffectHandler<E extends Exception> {
    * @param effect a consumer function that recieves the caught error
    * @return the same handler to continue chainning operations
    */
-  public <X extends Exception> EffectHandler<E> doOnError(final Class<X> ofType, final Consumer<X> effect) {
+  public <X extends Throwable> EffectHandler<E> doOnError(final Class<X> ofType, final Consumer<X> effect) {
     error.filter(ofType::isInstance)
       .map(ofType::cast)
       .ifPresent(effect);
@@ -153,7 +153,7 @@ public final class EffectHandler<E extends Exception> {
    * @return a new {@link EffectHandler} representing the result of one of the
    *         invoked callback
    */
-  public <X extends Exception> EffectHandler<X> runEffect(
+  public <X extends Throwable> EffectHandler<X> runEffect(
     final ThrowingRunnable<X> onSuccess,
     final ThrowingConsumer<E, X> onError
   ) {
@@ -171,7 +171,7 @@ public final class EffectHandler<E extends Exception> {
    * @return a new {@link EffectHandler} that is either empty or with the
    *         thrown error
    */
-  public <X extends Exception> EffectHandler<X> runEffect(final ThrowingRunnable<X> effect) {
+  public <X extends Throwable> EffectHandler<X> runEffect(final ThrowingRunnable<X> effect) {
     return this.runEffect(effect, err -> { });
   }
 

--- a/src/main/java/io/github/joselion/maybe/Maybe.java
+++ b/src/main/java/io/github/joselion/maybe/Maybe.java
@@ -93,13 +93,12 @@ public final class Maybe<T> {
    * @return a {@link ResolveHandler} with either the value resolved or the thrown
    *         exception to be handled
    */
-  public static <T, E extends Exception> ResolveHandler<T, E> fromResolver(final ThrowingSupplier<T, E> resolver) {
+  public static <T, E extends Throwable> ResolveHandler<T, E> fromResolver(final ThrowingSupplier<T, E> resolver) {
     try {
       return ResolveHandler.ofSuccess(resolver.get());
-    } catch (Exception e) {
+    } catch (Throwable e) { // NOSONAR
       @SuppressWarnings("unchecked")
-      final E error = (E) e;
-
+      final var error = (E) e;
       return ResolveHandler.ofError(error);
     }
   }
@@ -114,14 +113,13 @@ public final class Maybe<T> {
    * @return an {@link EffectHandler} with either the thrown exception to be
    *         handled or nothing
    */
-  public static <E extends Exception> EffectHandler<E> fromEffect(final ThrowingRunnable<E> effect) {
+  public static <E extends Throwable> EffectHandler<E> fromEffect(final ThrowingRunnable<E> effect) {
     try {
       effect.run();
       return EffectHandler.empty();
-    } catch (Exception e) {
+    } catch (Throwable e) { // NOSONAR
       @SuppressWarnings("unchecked")
-      final E error = (E) e;
-
+      final var error = (E) e;
       return EffectHandler.ofError(error);
     }
   }
@@ -152,7 +150,7 @@ public final class Maybe<T> {
    * @return a partially applied {@link ResolveHandler}. This means, a function
    *         that receives an {@code S} value, and produces a {@code ResolveHandler<T, E>}
    */
-  public static <S, T, E extends Exception> Function<S, ResolveHandler<T, E>> partialResolver(
+  public static <S, T, E extends Throwable> Function<S, ResolveHandler<T, E>> partialResolver(
     final ThrowingFunction<S, T, E> resolver
   ) {
     return value -> Maybe.fromResolver(() -> resolver.apply(value));
@@ -182,7 +180,7 @@ public final class Maybe<T> {
    * @return a partially applied {@link EffectHandler}. This means, a function
    *         that receives an {@code S} value, and produces an {@code EffectHandler<E>}
    */
-  public static <S, E extends Exception> Function<S, EffectHandler<E>> partialEffect(
+  public static <S, E extends Throwable> Function<S, EffectHandler<E>> partialEffect(
     final ThrowingConsumer<S, E> effect
   ) {
     return value -> Maybe.fromEffect(() -> effect.accept(value));
@@ -199,7 +197,7 @@ public final class Maybe<T> {
    * @return a {@link ResourceHolder} which let's you choose to resolve a value
    *         or run an effect using the prepared resource
    */
-  public static <R extends AutoCloseable, E extends Exception> ResourceHolder<R, E> withResource(final R resource) {
+  public static <R extends AutoCloseable, E extends Throwable> ResourceHolder<R, E> withResource(final R resource) {
     return ResourceHolder.from(resource);
   }
 
@@ -249,7 +247,7 @@ public final class Maybe<T> {
    *         thrown exception to be handled
    */
   @SuppressWarnings("unchecked")
-  public <U, E extends Exception> ResolveHandler<U, E> resolve(final ThrowingFunction<T, U, E> resolver) {
+  public <U, E extends Throwable> ResolveHandler<U, E> resolve(final ThrowingFunction<T, U, E> resolver) {
     try {
       return value
         .map(Maybe.partialResolver(resolver))
@@ -269,7 +267,7 @@ public final class Maybe<T> {
    *         handled or nothing
    */
   @SuppressWarnings("unchecked")
-  public <E extends Exception> EffectHandler<E> runEffect(final ThrowingConsumer<T, E> effect) {
+  public <E extends Throwable> EffectHandler<E> runEffect(final ThrowingConsumer<T, E> effect) {
     try {
       return value
         .map(Maybe.partialEffect(effect))
@@ -292,7 +290,7 @@ public final class Maybe<T> {
     try {
       final var newValue = type.cast(value.orElseThrow());
       return Maybe.just(newValue);
-    } catch (final Exception error) {
+    } catch (final ClassCastException error) {
       return nothing();
     }
   }

--- a/src/main/java/io/github/joselion/maybe/ResolveHandler.java
+++ b/src/main/java/io/github/joselion/maybe/ResolveHandler.java
@@ -22,7 +22,7 @@ import io.github.joselion.maybe.util.function.ThrowingFunction;
  * @author Jose Luis Leon
  * @since v0.3.2
  */
-public final class ResolveHandler<T, E extends Exception> {
+public final class ResolveHandler<T, E extends Throwable> {
 
   private final Either<E, T> value;
 
@@ -38,7 +38,7 @@ public final class ResolveHandler<T, E extends Exception> {
    * @param success the success value to instantiate the ResolveHandler
    * @return a ResolveHandler instance with a success value
    */
-  static <T, E extends Exception> ResolveHandler<T, E> ofSuccess(final T success) {
+  static <T, E extends Throwable> ResolveHandler<T, E> ofSuccess(final T success) {
     return new ResolveHandler<>(Either.ofRight(success));
   }
 
@@ -50,7 +50,7 @@ public final class ResolveHandler<T, E extends Exception> {
    * @param error the error to instantiate the ResolveHandler
    * @return a ResolveHandler instance with an error value
    */
-  static <T, E extends Exception> ResolveHandler<T, E> ofError(final E error) {
+  static <T, E extends Throwable> ResolveHandler<T, E> ofError(final E error) {
     return new ResolveHandler<>(Either.ofLeft(error));
   }
 
@@ -95,7 +95,7 @@ public final class ResolveHandler<T, E extends Exception> {
    * @param effect a consumer function that receives the caught error
    * @return the same handler to continue chainning operations
    */
-  public <X extends Exception> ResolveHandler<T, E> doOnError(final Class<X> ofType, final Consumer<X> effect) {
+  public <X extends Throwable> ResolveHandler<T, E> doOnError(final Class<X> ofType, final Consumer<X> effect) {
     value.leftToOptional()
       .filter(ofType::isInstance)
       .map(ofType::cast)
@@ -172,7 +172,7 @@ public final class ResolveHandler<T, E extends Exception> {
    *                      resolves another value
    * @return a new handler with either the resolved value or the error
    */
-  public <S, X extends Exception> ResolveHandler<S, X> resolve(
+  public <S, X extends Throwable> ResolveHandler<S, X> resolve(
     final ThrowingFunction<T, S, X> onSuccess,
     final ThrowingFunction<E, S, X> onError
   ) {
@@ -193,7 +193,7 @@ public final class ResolveHandler<T, E extends Exception> {
    * @return a new handler with either the resolved value or an error
    */
   @SuppressWarnings("unchecked")
-  public <S, X extends Exception> ResolveHandler<S, X> resolve(final ThrowingFunction<T, S, X> resolver) {
+  public <S, X extends Throwable> ResolveHandler<S, X> resolve(final ThrowingFunction<T, S, X> resolver) {
     return value.unwrap(
       error -> ResolveHandler.ofError((X) error),
       Maybe.partialResolver(resolver)
@@ -210,7 +210,7 @@ public final class ResolveHandler<T, E extends Exception> {
    * @return an {@link EffectHandler} representing the result of one of the
    *         invoked callback
    */
-  public <X extends Exception> EffectHandler<X> runEffect(
+  public <X extends Throwable> EffectHandler<X> runEffect(
     final ThrowingConsumer<T, X> onSuccess,
     final ThrowingConsumer<E, X> onError
   ) {
@@ -231,7 +231,7 @@ public final class ResolveHandler<T, E extends Exception> {
    *         callback or containg the error
    */
   @SuppressWarnings("unchecked")
-  public <X extends Exception> EffectHandler<X> runEffect(final ThrowingConsumer<T, X> effect) {
+  public <X extends Throwable> EffectHandler<X> runEffect(final ThrowingConsumer<T, X> effect) {
     return value.unwrap(
       error -> EffectHandler.ofError((X) error),
       Maybe.partialEffect(effect)

--- a/src/main/java/io/github/joselion/maybe/util/function/ThrowingConsumer.java
+++ b/src/main/java/io/github/joselion/maybe/util/function/ThrowingConsumer.java
@@ -13,13 +13,13 @@ package io.github.joselion.maybe.util.function;
  * @since v0.3.0
  */
 @FunctionalInterface
-public interface ThrowingConsumer<T, E extends Exception> {
+public interface ThrowingConsumer<T, E extends Throwable> {
 
   /**
    * Accepts this function with the given argument, or throws an exception.
    * 
    * @param t the consumer argument
-   * @throws E which extends from {@link Exception}
+   * @throws E which extends from {@link Throwable}
    */
   void accept(T t) throws E;
 }

--- a/src/main/java/io/github/joselion/maybe/util/function/ThrowingFunction.java
+++ b/src/main/java/io/github/joselion/maybe/util/function/ThrowingFunction.java
@@ -14,14 +14,14 @@ package io.github.joselion.maybe.util.function;
  * @since v0.1.0
  */
 @FunctionalInterface
-public interface ThrowingFunction<T, R, E extends Exception> {
+public interface ThrowingFunction<T, R, E extends Throwable> {
 
   /**
    * Applies this function to the given argument, or throws an exception.
    * 
    * @param t the function argument
    * @return the function result
-   * @throws E which extends from {@link Exception}
+   * @throws E which extends from {@link Throwable}
    */
   R apply(T t) throws E;
 
@@ -32,7 +32,7 @@ public interface ThrowingFunction<T, R, E extends Exception> {
    * @param <E> the type of exception that the function throws
    * @return a function that always returns its input argument
    */
-  static <T, E extends Exception> ThrowingFunction<T, T, E> identity() {
+  static <T, E extends Throwable> ThrowingFunction<T, T, E> identity() {
       return t -> t;
   }
 }

--- a/src/main/java/io/github/joselion/maybe/util/function/ThrowingRunnable.java
+++ b/src/main/java/io/github/joselion/maybe/util/function/ThrowingRunnable.java
@@ -12,12 +12,12 @@ package io.github.joselion.maybe.util.function;
  * @since v0.1.0
  */
 @FunctionalInterface
-public interface ThrowingRunnable<E extends Exception> {
+public interface ThrowingRunnable<E extends Throwable> {
 
   /**
    * Runs the operation, or throws an exception.
    * 
-   * @throws E which extends from {@link Exception}
+   * @throws E which extends from {@link Throwable}
    */
   void run() throws E;
 }

--- a/src/main/java/io/github/joselion/maybe/util/function/ThrowingSupplier.java
+++ b/src/main/java/io/github/joselion/maybe/util/function/ThrowingSupplier.java
@@ -13,13 +13,13 @@ package io.github.joselion.maybe.util.function;
  * @since v0.1.0
  */
 @FunctionalInterface
-public interface ThrowingSupplier<T, E extends Exception> {
+public interface ThrowingSupplier<T, E extends Throwable> {
 
   /**
    * Gets a result or throws an exception.
    * 
    * @return a result
-   * @throws E which extends from {@link Exception}
+   * @throws E which extends from {@link Throwable}
    */
   T get() throws E;
 }

--- a/src/test/java/io/github/joselion/maybe/MaybeTest.java
+++ b/src/test/java/io/github/joselion/maybe/MaybeTest.java
@@ -192,7 +192,7 @@ import io.github.joselion.testing.UnitTest;
           .isPresent()
           .containsInstanceOf(FileInputStream.class)
           .containsSame(fis);
-      } catch (Exception error) {
+      } catch (Throwable error) {
         throw new Error(error);
       }
     }

--- a/src/test/java/io/github/joselion/maybe/ResolveHandlerTest.java
+++ b/src/test/java/io/github/joselion/maybe/ResolveHandlerTest.java
@@ -360,7 +360,7 @@ import io.github.joselion.testing.UnitTest;
         final var handler = Maybe.fromResolver(okOp);
 
         assertThat(handler.orElse(OTHER)).isEqualTo(OK);
-        assertThat(handler.orElse(Exception::getMessage)).isEqualTo(OK);
+        assertThat(handler.orElse(RuntimeException::getMessage)).isEqualTo(OK);
       }
     }
 

--- a/src/test/java/io/github/joselion/maybe/ResourceHolderTest.java
+++ b/src/test/java/io/github/joselion/maybe/ResourceHolderTest.java
@@ -74,7 +74,7 @@ import io.github.joselion.testing.UnitTest;
     }
 
     @Nested class when_the_error_is_present {
-      @Test void returns_a_handler_with_the_propagated_error() throws Exception {
+      @Test void returns_a_handler_with_the_propagated_error() throws Throwable {
         final var error = new IOException("Something went wrong...");
         final var resolverSpy = Spy.<ThrowingFunction<AutoCloseable, ?, ?>>lambda(fis -> "");
         final var handler = ResourceHolder.failure(error)
@@ -127,7 +127,7 @@ import io.github.joselion.testing.UnitTest;
     }
 
     @Nested class when_the_error_is_present {
-      @Test void returns_a_handler_with_the_propagated_error() throws Exception {
+      @Test void returns_a_handler_with_the_propagated_error() throws Throwable {
         final var error = new IOException("Something went wrong...");
         final var effectSpy = Spy.<ThrowingConsumer<AutoCloseable, ?>>lambda(res -> { });
         final var handler = ResourceHolder.failure(error)


### PR DESCRIPTION
Generic exception types should extend from `Throwable`. Even though `Throwable` may also include `Error` instances, some common operations like reflection, method handles, etc. may throw a `Throwable` rather than an `Exception`, so it's better to be able to work with `Maybe` in those scenarios.