### PR TITLE
fix(core): Error propagation mismatch

### DIFF
--- a/src/main/java/io/github/joselion/maybe/Maybe.java
+++ b/src/main/java/io/github/joselion/maybe/Maybe.java
@@ -232,7 +232,7 @@ public final class Maybe<T> {
     return Maybe
       .from(supplier)
       .map(CloseableHandler::<R, E>from)
-      .orElse(CloseableHandler::failure);
+      .orElse(x -> CloseableHandler.failure(Commons.cast(x)));
   }
 
   /**

--- a/src/main/java17/io/github/joselion/maybe/Maybe.java
+++ b/src/main/java17/io/github/joselion/maybe/Maybe.java
@@ -233,7 +233,7 @@ public final class Maybe<T> {
     return Maybe
       .from(supplier)
       .map(CloseableHandler::<R, E>from)
-      .orElse(CloseableHandler::failure);
+      .orElse(x -> CloseableHandler.failure(Commons.cast(x)));
   }
 
   /**


### PR DESCRIPTION
Callbacks (Functions and Consumers) of the API that receive the actual error as a parameter need to change their generic type from `? super E` to a `Throwable`. Because the error propagates downstream in the API, we cannot guarantee that the current error type matches the Function/Consumer parameter type. If the types mismatch, we'll get a `ClassCastException` instead.