### PR TITLE
chore(ci): Revert codecov/codecov-action to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - run: ./gradlew test java17Test java21Test
       - run: ./gradlew build
       - run: ./gradlew jacocoTestReport --rerun
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
Codecov action does not pass the `token` argument on v4 when triggered by `workflow_call:`. Check https://github.com/codecov/codecov-action/issues/1292 for additional info.